### PR TITLE
perf(compositor): adaptive interpolation in CropSourceFrame

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -1197,3 +1197,18 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 **What worked:** `SetWindowsHookEx(WH_KEYBOARD_LL, ...)` with a managed callback that dispatches `CancelSelection` / `TrySetResult(null)` via `DispatcherQueue.TryEnqueue`. The delegate is stored as a field to prevent GC.
 
 **What didn't work:** Any approach relying on XAML keyboard focus (`Focus(FocusState.Programmatic)`, `KeyboardAccelerator`, `KeyDown` event) — XAML focus is not established on a borderless maximized overlay until the user clicks on a focusable element.
+
+
+---
+
+## Perf — FrameCompositor.CropSourceFrame Interpolation
+
+**Approaches tried:**
+
+1. **Adaptive interpolation: Linear when source→content scale is within ±5% of 1:1, otherwise HighQualityCubic** — Avoids running a 4-tap bicubic filter for every pixel on every frame in the common case (AspectRatio.Auto with no zoom, where viewport == content size, scale = exactly 1.0). Mirrors the same adaptive choice already present in ComposeFramePostCompositeZoom. ✅
+
+**What worked:** A small Math.Abs(scale - 1.0) < 0.05 guard around the interpolation choice. Hits every frame in both preview and export pipelines, and is visually equivalent to cubic at 1:1.
+
+**What didn't work:** N/A (single-pass change).
+
+---

--- a/src/Musio.Core/Processing/FrameCompositor.cs
+++ b/src/Musio.Core/Processing/FrameCompositor.cs
@@ -637,10 +637,26 @@ public class FrameCompositor : IDisposable
             _croppedBuffer = new CanvasRenderTarget(_device, _contentWidth, _contentHeight, 96);
         }
 
+        // Adaptive interpolation: HighQualityCubic is a 4-tap bicubic filter,
+        // significantly more expensive than Linear. It only meaningfully improves
+        // quality when actually resampling (zoom in/out or aspect-ratio crop with
+        // non-unit scale). At ~1:1 the bicubic filter produces output essentially
+        // identical to Linear, so use the cheaper path. This mirrors the choice
+        // already made in ComposeFramePostCompositeZoom for the zoom blit.
+        double scaleX = _contentWidth / viewport.Width;
+        double scaleY = _contentHeight / viewport.Height;
+        const double unitScaleTolerance = 0.05; // within ±5% of 1:1 → Linear
+        bool nearUnitScale =
+            Math.Abs(scaleX - 1.0) < unitScaleTolerance &&
+            Math.Abs(scaleY - 1.0) < unitScaleTolerance;
+        var interpolation = nearUnitScale
+            ? CanvasImageInterpolation.Linear
+            : CanvasImageInterpolation.HighQualityCubic;
+
         using var ds = _croppedBuffer.CreateDrawingSession();
         ds.Clear(Windows.UI.Color.FromArgb(0, 0, 0, 0));
         ds.DrawImage(source, new Rect(0, 0, _contentWidth, _contentHeight), viewport,
-            1f, CanvasImageInterpolation.HighQualityCubic);
+            1f, interpolation);
         return _croppedBuffer;
     }
 

--- a/src/Musio.Core/Processing/FrameCompositor.cs
+++ b/src/Musio.Core/Processing/FrameCompositor.cs
@@ -641,14 +641,16 @@ public class FrameCompositor : IDisposable
         // significantly more expensive than Linear. It only meaningfully improves
         // quality when actually resampling (zoom in/out or aspect-ratio crop with
         // non-unit scale). At ~1:1 the bicubic filter produces output essentially
-        // identical to Linear, so use the cheaper path. This mirrors the choice
-        // already made in ComposeFramePostCompositeZoom for the zoom blit.
+        // identical to Linear, so use the cheaper path. Use the same explicit
+        // near-unit threshold form as ComposeFramePostCompositeZoom so the two
+        // paths stay aligned over time.
         double scaleX = _contentWidth / viewport.Width;
         double scaleY = _contentHeight / viewport.Height;
-        const double unitScaleTolerance = 0.05; // within ±5% of 1:1 → Linear
+        const double nearUnitScaleMinimum = 0.95;
+        const double nearUnitScaleMaximum = 1.05;
         bool nearUnitScale =
-            Math.Abs(scaleX - 1.0) < unitScaleTolerance &&
-            Math.Abs(scaleY - 1.0) < unitScaleTolerance;
+            scaleX >= nearUnitScaleMinimum && scaleX <= nearUnitScaleMaximum &&
+            scaleY >= nearUnitScaleMinimum && scaleY <= nearUnitScaleMaximum;
         var interpolation = nearUnitScale
             ? CanvasImageInterpolation.Linear
             : CanvasImageInterpolation.HighQualityCubic;


### PR DESCRIPTION
Use Linear interpolation when source-to-content scale is within ±5% of 1:1, otherwise keep HighQualityCubic. The bicubic filter is a 4-tap per-pixel operation that's run on every frame of every preview and every export. When AspectRatio is Auto and zoom is inactive the viewport equals the content size, so the bicubic resample is wasted work — Linear is visually identical at 1:1 scale. Mirrors the adaptive interpolation choice already used in the
post-composite-zoom blit path.