### PR TITLE
Fix region picker UX: pre-render selection, signal cancel, persist VM

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -1253,3 +1253,32 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 - **Feature/area**: `RecordingViewModel.GetCaptureTarget` (CustomRegion mode).
 - **What worked**: When the saved `CaptureRegion.MonitorId` no longer matches any connected monitor, clear `SelectedRegion`/`HasSelectedRegion`, surface `RecordingStatus` ('Saved region's monitor is no longer connected — please select a new region'), and return null. This forces the user to reselect on the current display topology.
 - **What didn't work**: Silently falling back to `allMonitors.FirstOrDefault()` — the region's monitor-local DIPs got applied to the wrong (primary) monitor, producing a clamped/off-screen capture and a misplaced red border.
+## Region Picker — "blank on open / silent on cancel" confusion
+
+**Approaches tried:**
+
+1. **Pre-render initial region in `RegionSelectorOverlay.OnLoaded`** — Worked. Added `ShowAsync(CaptureRegion? initialRegion)` overload; `OnLoaded` now seeds `_selX/_selY/_selW/_selH` and `_hasSelection = true` from the caller-supplied region (or persisted last region as fallback), then calls `UpdateOverlay()`. User now opens onto their existing rectangle with handles instead of a blank dark canvas. ?
+2. **Track cancel vs confirm via `WasCancelled` property on the overlay** — Worked. `CancelSelection` sets `WasCancelled = true` before resolving the TCS with null. `RecordingPage.LaunchRegionPickerAsync` reads it after `ShowAsync` returns null to distinguish "user pressed Escape ? no-op" from "first-time open with no prior selection". On Escape with an existing selection, page shows an InfoBar: *"Region selection cancelled — kept previous region."* — eliminates the pixel-identical confusion. ?
+
+**What worked:** Both fixes together. Pre-render eliminates the blank-screen surprise; InfoBar makes Escape's no-op explicit.
+
+**What didn't work / not chosen:**
+
+- Returning a richer result type (e.g. `RegionPickerResult { Region, WasCancelled }`) — would be cleaner but required more surface area changes; `WasCancelled` as a property on the overlay (already a stateful UserControl) was the smaller diff.
+
+---
+
+## Recording state lost on page navigation
+
+**Approaches tried:**
+
+1. **Per-page `RecordingViewModel` (original)** — Didn't work. `RecordingPage` declared `public RecordingViewModel ViewModel { get; } = new();` so every navigation back to the page constructed a fresh VM, losing `CaptureMode`, `SelectedWindow`, `SelectedRegion`, `HasSelectedRegion`, and audio toggles. Region survived only because it was persisted to `ApplicationData.LocalSettings` via `RegionMemory`.
+2. **Shared singleton `RecordingViewModel.Shared`** — Worked. Page now uses `ViewModel { get; } = RecordingViewModel.Shared;` so all selection state survives Editor ? Record navigation. ?
+3. **Per-navigation event subscription** — Required companion fix. Constructor-based `ViewModel.PropertyChanged += …` on a shared VM would leak page references (the VM holds the lambda which captures `this`). Moved subscription to `OnNavigatedTo` and added matching tear-down in `OnNavigatedFrom` so prior page instances can be GC'd. ?
+
+**What worked:** Shared VM + navigation-scoped event lifecycle.
+
+**What didn't work / not chosen:**
+
+- Re-hydrating only `SelectedRegion` from `LoadLastRegion()` in `UpdateRegionInfoDisplay` (already existed) — insufficient because `CaptureMode` and `SelectedWindow` were not persisted, and on fresh-install `LocalSettings` is empty.
+- `NavigationCacheMode=Required` on the page — would also work but caches the entire visual tree; singleton VM is a smaller, more explicit contract.

--- a/learnings.md
+++ b/learnings.md
@@ -1332,3 +1332,16 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 **What worked:** Reading `PointerRoutedEventArgs.KeyModifiers` directly (no separate keyboard hook). Computing the anchor corner in display coords at `PointerPressed` and re-projecting the new center display position back to normalized coords keeps the opposite corner fixed across resize. Clamping zoom first, then deriving effective scale, avoids the rect drifting outside `[1.5, 4.0]`.
 
 **What didn't work / rejected:** Letting the corner handle `Rectangle` elements be hit-test-visible ? would steal pointer capture from the `Canvas` and break the existing drag handlers. Solution: keep handles purely cosmetic and do manual hit testing.
+
+---
+
+## Region Selector Overlay & Recording Page — PR Review Fixes
+
+**Approaches tried:**
+
+1. **TryApplyPresetRegion coordinate space bug** — Was assigning CaptureRegion.X/Y/Width/Height (monitor-local DIPs) directly into overlay selection coords (virtual-desktop overlay DIPs). On multi-monitor / mixed-DPI this seeded the wrong place/size. Fixed by converting monitor-local DIPs ? physical pixels (using saved monitor's origin + GetMonitorDpiScale) ? overlay DIPs (subtract virtual-desktop origin from SM_X/YVIRTUALSCREEN, divide by _screenshotWidth/ActualWidth). ?
+2. **UpdateOverlay degenerate-selection state leak** — When sw/sh clamped to <=0, the blank overlay rendered but _hasSelection and ButtonPanel.Visibility were left set. Now clears _hasSelection/_sel* and hides ButtonPanel in the degenerate branch. ?
+3. **RecordingPage._infoBarTimer navigation leak** — Timer was created on the page's DispatcherQueue and retained OnInfoBarTimerTick, keeping the page alive after navigation. Now Stop() + detach Tick handler + close InfoBar in OnNavigatedFrom. ?
+
+**What worked:** All three above.
+

--- a/src/Musio.App/Controls/RegionSelectorOverlay.xaml.cs
+++ b/src/Musio.App/Controls/RegionSelectorOverlay.xaml.cs
@@ -44,6 +44,19 @@ public sealed partial class RegionSelectorOverlay : UserControl
     private InputSystemCursorShape _currentCursorShape = InputSystemCursorShape.Cross;
     private static readonly Dictionary<InputSystemCursorShape, InputSystemCursor> _cursorCache = new();
 
+    // Region passed by the caller to be pre-rendered on open. Set by ShowAsync
+    // before the overlay window is activated so OnLoaded can apply it.
+    private CaptureRegion? _initialRegion;
+
+    /// <summary>
+    /// True when the most recent <see cref="ShowAsync"/> call ended because the
+    /// user pressed Escape / Cancel rather than confirming a selection.
+    /// Read by callers to distinguish "cancelled — keep prior selection" from
+    /// "confirmed identical selection" (both return the same region value via
+    /// the persisted last-region, but only the former should suppress UI churn).
+    /// </summary>
+    public bool WasCancelled { get; private set; }
+
     private const double HandleSize = 8;
     private const double HandleHitArea = 16;
     private const double MinSelectionSize = 10;
@@ -72,8 +85,53 @@ public sealed partial class RegionSelectorOverlay : UserControl
             UseLastButton.Visibility = Visibility.Visible;
         }
 
+        // Pre-render the caller-supplied region (or fall back to the persisted
+        // last region) so the user opens to their existing selection rather
+        // than a blank dark screen.
+        TryApplyPresetRegion(_initialRegion ?? lastRegion);
+
         UpdateOverlay();
         Focus(FocusState.Programmatic);
+    }
+
+    /// <summary>
+    /// Validates <paramref name="preset"/> against the current overlay canvas
+    /// and, if it intersects, seeds the selection state and shows the Confirm
+    /// button panel. Rejects degenerate / off-screen regions silently so a
+    /// stale persisted region from a disconnected monitor or older layout
+    /// does not produce negative-size rendering in <see cref="UpdateOverlay"/>.
+    /// </summary>
+    private void TryApplyPresetRegion(CaptureRegion? preset)
+    {
+        if (preset is null || preset.Width <= 0 || preset.Height <= 0)
+            return;
+
+        // If layout isn't ready yet, OnSizeChanged will call UpdateOverlay
+        // once ActualWidth/Height become valid; trust the preset for now.
+        double canvasW = ActualWidth;
+        double canvasH = ActualHeight;
+        if (canvasW > 0 && canvasH > 0)
+        {
+            // Reject regions that don't intersect the current virtual desktop
+            // (e.g. saved on a now-disconnected monitor).
+            bool intersects = preset.X < canvasW
+                && preset.Y < canvasH
+                && preset.X + preset.Width > 0
+                && preset.Y + preset.Height > 0;
+            if (!intersects)
+                return;
+        }
+
+        _selX = preset.X;
+        _selY = preset.Y;
+        _selW = preset.Width;
+        _selH = preset.Height;
+        _hasSelection = true;
+
+        // Pre-rendered selections need the Confirm/Cancel buttons immediately —
+        // they're normally only shown on pointer-up of a fresh drag.
+        if (ButtonPanel is not null)
+            ButtonPanel.Visibility = Visibility.Visible;
     }
 
     private void OnSizeChanged(object sender, SizeChangedEventArgs e)
@@ -85,8 +143,17 @@ public sealed partial class RegionSelectorOverlay : UserControl
     /// Opens a borderless maximized window with this overlay and waits for the user to
     /// confirm a selection or cancel.
     /// </summary>
-    public async Task<CaptureRegion?> ShowAsync()
+    public Task<CaptureRegion?> ShowAsync() => ShowAsync(null);
+
+    /// <summary>
+    /// Opens the overlay pre-populated with <paramref name="initialRegion"/>
+    /// (if non-null) so the user can refine an existing selection instead of
+    /// starting from a blank canvas.
+    /// </summary>
+    public async Task<CaptureRegion?> ShowAsync(CaptureRegion? initialRegion)
     {
+        _initialRegion = initialRegion;
+        WasCancelled = false;
         _tcs = new TaskCompletionSource<CaptureRegion?>();
 
         // Minimize Musio so it doesn't appear in the screenshot
@@ -142,7 +209,15 @@ public sealed partial class RegionSelectorOverlay : UserControl
         if (screenshotSource is not null)
             ScreenshotImage.Source = screenshotSource;
 
-        _hostWindow.Closed += (_, _) => _tcs.TrySetResult(null);
+        _hostWindow.Closed += (_, _) =>
+        {
+            // System-close (Alt+F4, taskbar close, etc.) skips the explicit
+            // CancelSelection path, so flag it as a cancel so callers still
+            // get the "kept previous region" hint.
+            if (!_tcs.Task.IsCompleted)
+                WasCancelled = true;
+            _tcs.TrySetResult(null);
+        };
 
         // Install low-level keyboard hook so Escape works even without XAML focus
         _hookProc = EscapeHookCallback;
@@ -275,11 +350,31 @@ public sealed partial class RegionSelectorOverlay : UserControl
             return;
         }
 
-        // Clamp selection to canvas
+        // Clamp selection to canvas. canvasW - sx can be negative when a stale
+        // preset region lies off the current virtual desktop, so guard the
+        // width/height against negative values rather than letting them flow
+        // into Rectangle.Width (which throws / renders incorrectly).
         double sx = Math.Max(0, _selX);
         double sy = Math.Max(0, _selY);
-        double sw = Math.Min(Math.Max(0, _selW), canvasW - sx);
-        double sh = Math.Min(Math.Max(0, _selH), canvasH - sy);
+        double sw = Math.Max(0, Math.Min(Math.Max(0, _selW), canvasW - sx));
+        double sh = Math.Max(0, Math.Min(Math.Max(0, _selH), canvasH - sy));
+
+        if (sw <= 0 || sh <= 0)
+        {
+            // Degenerate selection (entirely off-screen) — show the blank
+            // overlay so the user can drag a new one.
+            Canvas.SetLeft(TopMask, 0);
+            Canvas.SetTop(TopMask, 0);
+            TopMask.Width = canvasW;
+            TopMask.Height = canvasH;
+            BottomMask.Width = 0; BottomMask.Height = 0;
+            LeftMask.Width = 0; LeftMask.Height = 0;
+            RightMask.Width = 0; RightMask.Height = 0;
+            SelectionRect.Visibility = Visibility.Collapsed;
+            DimensionLabel.Visibility = Visibility.Collapsed;
+            HideHandles();
+            return;
+        }
 
         // Top mask
         Canvas.SetLeft(TopMask, 0);
@@ -807,6 +902,7 @@ public sealed partial class RegionSelectorOverlay : UserControl
 
     private void CancelSelection()
     {
+        WasCancelled = true;
         SelectionCancelled?.Invoke(this, EventArgs.Empty);
         _tcs?.TrySetResult(null);
     }

--- a/src/Musio.App/Controls/RegionSelectorOverlay.xaml.cs
+++ b/src/Musio.App/Controls/RegionSelectorOverlay.xaml.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.UI.Input;
@@ -106,26 +107,57 @@ public sealed partial class RegionSelectorOverlay : UserControl
         if (preset is null || preset.Width <= 0 || preset.Height <= 0)
             return;
 
-        // If layout isn't ready yet, OnSizeChanged will call UpdateOverlay
-        // once ActualWidth/Height become valid; trust the preset for now.
+        // CaptureRegion is stored as monitor-local DIPs (see ConfirmSelection),
+        // but the overlay's selection coordinates are virtual-desktop overlay
+        // DIPs. Convert monitor-local DIPs → physical pixels (using the saved
+        // monitor's origin + effective DPI) → overlay DIPs before seeding the
+        // selection so multi-monitor / mixed-DPI presets render correctly.
+        var monitor = _regionSelector.GetMonitors().FirstOrDefault(m => m.Id == preset.MonitorId);
+        if (monitor is null)
+            return;
+
+        float dpiScale = GetMonitorDpiScale(monitor.Handle);
+        if (dpiScale <= 0) dpiScale = 1.0f;
+
+        // Monitor-local DIPs → screen-absolute physical pixels.
+        double physX = monitor.X + preset.X * dpiScale;
+        double physY = monitor.Y + preset.Y * dpiScale;
+        double physW = preset.Width * dpiScale;
+        double physH = preset.Height * dpiScale;
+
+        // Physical pixels → overlay DIPs. The overlay canvas spans the entire
+        // virtual desktop; _screenshotWidth/Height are the virtual desktop in
+        // physical pixels, ActualWidth/Height are the same in overlay DIPs.
         double canvasW = ActualWidth;
         double canvasH = ActualHeight;
-        if (canvasW > 0 && canvasH > 0)
-        {
-            // Reject regions that don't intersect the current virtual desktop
-            // (e.g. saved on a now-disconnected monitor).
-            bool intersects = preset.X < canvasW
-                && preset.Y < canvasH
-                && preset.X + preset.Width > 0
-                && preset.Y + preset.Height > 0;
-            if (!intersects)
-                return;
-        }
+        if (canvasW <= 0 || canvasH <= 0 || _screenshotWidth <= 0 || _screenshotHeight <= 0)
+            return;
 
-        _selX = preset.X;
-        _selY = preset.Y;
-        _selW = preset.Width;
-        _selH = preset.Height;
+        int vdLeft = GetSystemMetrics(SM_XVIRTUALSCREEN);
+        int vdTop = GetSystemMetrics(SM_YVIRTUALSCREEN);
+        double scaleX = _screenshotWidth / canvasW; // phys-per-overlay-DIP
+        double scaleY = _screenshotHeight / canvasH;
+        if (scaleX <= 0 || scaleY <= 0)
+            return;
+
+        double overlayX = (physX - vdLeft) / scaleX;
+        double overlayY = (physY - vdTop) / scaleY;
+        double overlayW = physW / scaleX;
+        double overlayH = physH / scaleY;
+
+        // Reject regions that don't intersect the current virtual desktop
+        // (e.g. saved on a now-disconnected monitor).
+        bool intersects = overlayX < canvasW
+            && overlayY < canvasH
+            && overlayX + overlayW > 0
+            && overlayY + overlayH > 0;
+        if (!intersects)
+            return;
+
+        _selX = overlayX;
+        _selY = overlayY;
+        _selW = overlayW;
+        _selH = overlayH;
         _hasSelection = true;
 
         // Pre-rendered selections need the Confirm/Cancel buttons immediately —
@@ -361,8 +393,15 @@ public sealed partial class RegionSelectorOverlay : UserControl
 
         if (sw <= 0 || sh <= 0)
         {
-            // Degenerate selection (entirely off-screen) — show the blank
-            // overlay so the user can drag a new one.
+            // Degenerate selection (entirely off-screen) — clear selection
+            // state so Confirm/Cancel buttons hide and the next pointer-down
+            // starts a fresh drag rather than resizing the invisible region.
+            _hasSelection = false;
+            _selX = _selY = _selW = _selH = 0;
+            if (ButtonPanel is not null)
+                ButtonPanel.Visibility = Visibility.Collapsed;
+
+            // Show the blank overlay so the user can drag a new one.
             Canvas.SetLeft(TopMask, 0);
             Canvas.SetTop(TopMask, 0);
             TopMask.Width = canvasW;

--- a/src/Musio.App/Pages/RecordingPage.xaml.cs
+++ b/src/Musio.App/Pages/RecordingPage.xaml.cs
@@ -15,7 +15,7 @@ namespace Musio_App.Pages;
 
 public sealed partial class RecordingPage : Page
 {
-    public RecordingViewModel ViewModel { get; } = new();
+    public RecordingViewModel ViewModel { get; } = RecordingViewModel.Shared;
 
     private readonly RegionSelector _regionSelector = new();
     private RecordingOverlayWindow? _overlayWindow;
@@ -24,15 +24,28 @@ public sealed partial class RecordingPage : Page
     private bool _isPageLoading = true;
     private bool _isPickerOpen;
 
+    private System.ComponentModel.PropertyChangedEventHandler? _viewModelHandler;
+
     public RecordingPage()
     {
         InitializeComponent();
-        ViewModel.SetDispatcher(DispatcherQueue);
         Loaded += OnLoaded;
+    }
 
-        ViewModel.PropertyChanged += (_, e) =>
+    protected override void OnNavigatedTo(Microsoft.UI.Xaml.Navigation.NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
+
+        // Re-point the shared VM's dispatcher at this page's UI thread (cheap;
+        // safe to call repeatedly).
+        ViewModel.SetDispatcher(DispatcherQueue);
+
+        // Wire up IsRecording observation per-navigation; tear down in
+        // OnNavigatedFrom so the VM doesn't accumulate handlers from prior page
+        // instances.
+        _viewModelHandler = (_, args) =>
         {
-            if (e.PropertyName != nameof(RecordingViewModel.IsRecording)) return;
+            if (args.PropertyName != nameof(RecordingViewModel.IsRecording)) return;
 
             DispatcherQueue.TryEnqueue(() =>
             {
@@ -49,6 +62,17 @@ public sealed partial class RecordingPage : Page
                 }
             });
         };
+        ViewModel.PropertyChanged += _viewModelHandler;
+    }
+
+    protected override void OnNavigatedFrom(Microsoft.UI.Xaml.Navigation.NavigationEventArgs e)
+    {
+        if (_viewModelHandler is not null)
+        {
+            ViewModel.PropertyChanged -= _viewModelHandler;
+            _viewModelHandler = null;
+        }
+        base.OnNavigatedFrom(e);
     }
 
     private async void StartRecordButton_Click(object sender, RoutedEventArgs e)
@@ -285,7 +309,7 @@ public sealed partial class RecordingPage : Page
         try
         {
             var overlay = new RegionSelectorOverlay();
-            var region = await overlay.ShowAsync();
+            var region = await overlay.ShowAsync(ViewModel.SelectedRegion);
 
             if (region is not null)
             {
@@ -293,11 +317,44 @@ public sealed partial class RecordingPage : Page
                 ViewModel.HasSelectedRegion = true;
                 UpdateRegionInfoDisplay();
             }
+            else if (overlay.WasCancelled && ViewModel.HasSelectedRegion)
+            {
+                // Pixel-identical dimensions before/after cancel make the no-op
+                // invisible — surface an explicit "kept previous region" hint.
+                ShowTransientInfo("Region selection cancelled — kept previous region.");
+            }
         }
         finally
         {
             _isPickerOpen = false;
         }
+    }
+
+    private Microsoft.UI.Dispatching.DispatcherQueueTimer? _infoBarTimer;
+
+    private void ShowTransientInfo(string message)
+    {
+        if (RecordingInfoBar is null) return;
+        RecordingInfoBar.Severity = InfoBarSeverity.Informational;
+        RecordingInfoBar.Title = string.Empty;
+        RecordingInfoBar.Message = message;
+        RecordingInfoBar.IsOpen = true;
+
+        // Auto-dismiss after a few seconds so the bar doesn't linger forever.
+        _infoBarTimer?.Stop();
+        _infoBarTimer ??= DispatcherQueue.CreateTimer();
+        _infoBarTimer.Interval = TimeSpan.FromSeconds(4);
+        _infoBarTimer.IsRepeating = false;
+        _infoBarTimer.Tick -= OnInfoBarTimerTick;
+        _infoBarTimer.Tick += OnInfoBarTimerTick;
+        _infoBarTimer.Start();
+    }
+
+    private void OnInfoBarTimerTick(Microsoft.UI.Dispatching.DispatcherQueueTimer sender, object args)
+    {
+        if (RecordingInfoBar is not null)
+            RecordingInfoBar.IsOpen = false;
+        sender.Stop();
     }
 
     private void UpdateWindowInfoDisplay()

--- a/src/Musio.App/Pages/RecordingPage.xaml.cs
+++ b/src/Musio.App/Pages/RecordingPage.xaml.cs
@@ -72,6 +72,18 @@ public sealed partial class RecordingPage : Page
             ViewModel.PropertyChanged -= _viewModelHandler;
             _viewModelHandler = null;
         }
+
+        // Detach the InfoBar timer so it can't fire (and keep this page alive)
+        // after navigation. The timer is created on this page's DispatcherQueue
+        // and retains OnInfoBarTimerTick.
+        if (_infoBarTimer is not null)
+        {
+            _infoBarTimer.Stop();
+            _infoBarTimer.Tick -= OnInfoBarTimerTick;
+        }
+        if (RecordingInfoBar is not null)
+            RecordingInfoBar.IsOpen = false;
+
         base.OnNavigatedFrom(e);
     }
 

--- a/src/Musio.App/ViewModels/RecordingViewModel.cs
+++ b/src/Musio.App/ViewModels/RecordingViewModel.cs
@@ -18,6 +18,15 @@ public enum CaptureMode
 
 public partial class RecordingViewModel : ObservableObject
 {
+    /// <summary>
+    /// Process-wide singleton so capture mode, selected region/window, and audio
+    /// toggles survive page navigation (e.g. Editor → Record). The
+    /// <see cref="RecordingPage"/> wires up to this instance via
+    /// <c>OnNavigatedTo</c>/<c>OnNavigatedFrom</c> rather than constructor
+    /// subscriptions to avoid handler leaks.
+    /// </summary>
+    public static RecordingViewModel Shared { get; } = new();
+
     private RecordingSession? _session;
     private System.Threading.Timer? _elapsedTimer;
     private Microsoft.UI.Dispatching.DispatcherQueue? _dispatcher;


### PR DESCRIPTION
The region picker opened to a blank dark canvas even when a region was remembered, and pressing Escape silently kept the prior selection - with pixel-identical dimensions, the user couldn't tell whether anything had happened. State was also reset whenever the user navigated Editor -> Record because RecordingPage constructed a fresh RecordingViewModel each time.

Changes:

- RegionSelectorOverlay: new ShowAsync(CaptureRegion? initialRegion) overload pre-populates the selection and shows Confirm/Cancel buttons on open; off-screen / disconnected-monitor presets are rejected via canvas intersection check; UpdateOverlay clamps width/height defensively so a stale preset can't produce negative Rectangle dimensions.
- RegionSelectorOverlay: WasCancelled property + system-close path set it, so callers can distinguish Escape from confirmation of an identical region.
- RecordingPage: passes ViewModel.SelectedRegion into ShowAsync; on cancel with an existing selection shows a transient InfoBar (kept previous region) that auto-dismisses after 4s via DispatcherQueueTimer.
- RecordingViewModel.Shared: singleton VM so CaptureMode, SelectedRegion, SelectedWindow, and audio toggles survive page navigation.
- RecordingPage: PropertyChanged subscription moved from constructor to OnNavigatedTo / OnNavigatedFrom so the shared VM doesn't accumulate handlers from prior page instances.