### PR TITLE
Add spacebar shortcut for preview play/pause

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -1345,3 +1345,17 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 
 **What worked:** All three above.
 
+
+---
+
+## Editor — Spacebar Play/Pause Shortcut
+
+**Feature/area:** EditorPage keyboard accelerators / Preview playback.
+
+**Approaches tried:**
+
+1. **Page-level `KeyboardAccelerator` with `Key="Space"` invoking `Preview.Play()`/`Preview.Pause()` based on `Preview.IsPlaying`** — Worked. ?
+2. **Skip handler when a text input has focus** — Used `FocusManager.GetFocusedElement(XamlRoot)` and bailed for `TextBox`/`PasswordBox`/`RichEditBox`/`AutoSuggestBox` so typing a space in editable fields isn't hijacked. ?
+
+**What worked:** XAML accelerator + focus-check guard in the handler.
+

--- a/src/Musio.App/Pages/EditorPage.xaml
+++ b/src/Musio.App/Pages/EditorPage.xaml
@@ -28,6 +28,9 @@
             Key="X"
             Invoked="CutAccelerator_Invoked"
             Modifiers="Control" />
+        <KeyboardAccelerator
+            Key="Space"
+            Invoked="PlayPauseAccelerator_Invoked" />
     </Page.KeyboardAccelerators>
 
     <Grid>

--- a/src/Musio.App/Pages/EditorPage.xaml.cs
+++ b/src/Musio.App/Pages/EditorPage.xaml.cs
@@ -840,6 +840,50 @@ public sealed partial class EditorPage : Page
         args.Handled = true;
     }
 
+    private void PlayPauseAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+    {
+        if (IsFocusOnInteractiveControl())
+        {
+            return;
+        }
+
+        if (Preview.IsPlaying)
+        {
+            Preview.Pause();
+        }
+        else
+        {
+            Preview.Play();
+        }
+        args.Handled = true;
+    }
+
+    private bool IsFocusOnInteractiveControl()
+    {
+        DependencyObject? node = FocusManager.GetFocusedElement(XamlRoot) as DependencyObject;
+        while (node is not null)
+        {
+            switch (node)
+            {
+                case TextBox:
+                case PasswordBox:
+                case RichEditBox:
+                case AutoSuggestBox:
+                case ComboBox:
+                case NumberBox:
+                case Microsoft.UI.Xaml.Controls.Primitives.ButtonBase:
+                case ToggleSwitch:
+                case Slider:
+                case ColorPicker:
+                case FlyoutPresenter:
+                case MenuFlyoutPresenter:
+                    return true;
+            }
+            node = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(node);
+        }
+        return false;
+    }
+
     // --- Zoom Segment Handlers ---
 
     private bool _suppressZoomPropertyUpdate;


### PR DESCRIPTION
Adds a Page-level KeyboardAccelerator on EditorPage that toggles

Preview.Play()/Pause(). Guards against hijacking Space on focused

interactive controls (text inputs, ButtonBase, ToggleSwitch, ComboBox,

NumberBox, Slider, ColorPicker) and inside open flyouts by walking

the focused element's visual-tree ancestors.