### PR TITLE
Fix focal-point snap across overlapping zoom segments

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -1359,3 +1359,22 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 
 **What worked:** XAML accelerator + focus-check guard in the handler.
 
+
+
+---
+
+## Overlapping Zoom Segments — Center Snap Fix
+
+**Feature/area:** AutoZoomEngine — focal-point continuity across overlapping zoom segments
+
+**Approaches tried:**
+1. Earlier fix used max-zoom-wins for both zoom level and center (cx/cy). Zoom level stayed continuous, but the *center* snapped at the instant B's zoom first exceeded A's, since the winning keyframe's center was used wholesale. Editing a segment moved where this snap occurred, making the visual jump obvious.
+2. Blend centers by per-keyframe "activation weight" (max(0, zoom - 1)) while still using max-zoom for the zoom level. ?
+
+**What worked:**
+- In `EvaluateManualKeyframes` and `EvaluateAutoSegments`: compute `w = max(0, zoom - 1)` per active segment, accumulate `weighted sum of cx/cy`, return `weightSum > eps ? sum/weight : maxZoomSegmentCenter`.
+- This guarantees: at A-only the center = cA; at the crossover it's a smooth weighted blend; at B-only the center = cB. No focal-point snap regardless of how segments are edited.
+- Regression test `GetZoomState_OverlappingManualKeyframes_CenterDoesNotSnap` steps through the overlap and asserts per-step center delta stays well under the would-be snap magnitude.
+
+**What didn't work:**
+- Returning the max-zoom segment's center as-is — produces a discontinuous jump at the crossover when overlapping segments have different centers.

--- a/src/Musio.Core/Processing/AutoZoomEngine.cs
+++ b/src/Musio.Core/Processing/AutoZoomEngine.cs
@@ -228,8 +228,21 @@ public class AutoZoomEngine
     private (float zoom, float cx, float cy)? EvaluateManualKeyframes(double timeSeconds)
     {
         // When multiple keyframes overlap (e.g. A zooming out while B zooms in),
-        // pick the one producing the highest zoom level for a seamless crossover.
-        (float zoom, float cx, float cy)? best = null;
+        // use max-zoom for the zoom level but blend centers by each keyframe's
+        // "activation weight" (zoom - 1) so the focal point glides smoothly
+        // from A's center to B's center across the overlap, instead of snapping
+        // at the instant B's zoom first exceeds A's.
+        bool anyActive = false;
+        float bestZoom = float.NegativeInfinity;
+        double weightSum = 0.0;
+        double cxSum = 0.0;
+        double cySum = 0.0;
+        // Fallback center (in case all weights are ~0 within the overlap region):
+        // track the center of the keyframe currently contributing the max zoom.
+        // Initialized to source center but always overridden as soon as any
+        // segment is active (since bestZoom starts at -inf).
+        float fallbackCx = _sourceWidth / 2f;
+        float fallbackCy = _sourceHeight / 2f;
 
         foreach (var kf in _manualKeyframes)
         {
@@ -264,20 +277,49 @@ public class AutoZoomEngine
             float cx = (float)(kf.CenterX * _sourceWidth);
             float cy = (float)(kf.CenterY * _sourceHeight);
 
-            if (!best.HasValue || zoom > best.Value.zoom)
-                best = (zoom, cx, cy);
+            anyActive = true;
+            double w = Math.Max(0.0, zoom - 1.0);
+            weightSum += w;
+            cxSum += w * cx;
+            cySum += w * cy;
+
+            if (zoom > bestZoom)
+            {
+                bestZoom = zoom;
+                fallbackCx = cx;
+                fallbackCy = cy;
+            }
         }
 
-        return best;
+        if (!anyActive)
+            return null;
+
+        float outCx, outCy;
+        if (weightSum > 1e-6)
+        {
+            outCx = (float)(cxSum / weightSum);
+            outCy = (float)(cySum / weightSum);
+        }
+        else
+        {
+            outCx = fallbackCx;
+            outCy = fallbackCy;
+        }
+
+        return (bestZoom, outCx, outCy);
     }
 
     private (float zoom, float cx, float cy) EvaluateAutoSegments(double timeSeconds)
     {
-        // When segments overlap (edge cases after merge), pick the highest zoom
-        // for a seamless transition — same strategy as manual keyframes.
+        // Same strategy as manual keyframes: max zoom for level, weighted
+        // average for center to avoid focal-point snaps across overlapping
+        // segments.
         float bestZoom = 1.0f;
-        float bestCx = _sourceWidth / 2f;
-        float bestCy = _sourceHeight / 2f;
+        float fallbackCx = _sourceWidth / 2f;
+        float fallbackCy = _sourceHeight / 2f;
+        double weightSum = 0.0;
+        double cxSum = 0.0;
+        double cySum = 0.0;
 
         foreach (var seg in _autoSegments)
         {
@@ -302,15 +344,32 @@ public class AutoZoomEngine
                 zoom = CubicBezierEase(seg.TargetZoom, 1.0f, (float)progress);
             }
 
+            double w = Math.Max(0.0, zoom - 1.0);
+            weightSum += w;
+            cxSum += w * seg.CenterX;
+            cySum += w * seg.CenterY;
+
             if (zoom > bestZoom)
             {
                 bestZoom = zoom;
-                bestCx = seg.CenterX;
-                bestCy = seg.CenterY;
+                fallbackCx = seg.CenterX;
+                fallbackCy = seg.CenterY;
             }
         }
 
-        return (bestZoom, bestCx, bestCy);
+        float outCx, outCy;
+        if (weightSum > 1e-6)
+        {
+            outCx = (float)(cxSum / weightSum);
+            outCy = (float)(cySum / weightSum);
+        }
+        else
+        {
+            outCx = fallbackCx;
+            outCy = fallbackCy;
+        }
+
+        return (bestZoom, outCx, outCy);
     }
 
     /// <summary>

--- a/src/Musio.Tests/AutoZoomEngineTests.cs
+++ b/src/Musio.Tests/AutoZoomEngineTests.cs
@@ -343,4 +343,84 @@ public sealed class AutoZoomEngineTests
         Assert.IsFalse(hadJump,
             "Zoom should not have sudden drops during overlapping keyframe transition");
     }
+
+    [TestMethod]
+    public void GetZoomState_OverlappingManualKeyframes_CenterDoesNotSnap()
+    {
+        // Regression: when two overlapping keyframes have different centers,
+        // the focal point should glide smoothly from A to B rather than
+        // snapping at the moment B's zoom first exceeds A's.
+        const int W = 1920;
+        const int H = 1080;
+        var config = new AutoZoomConfig();
+        var engine = new AutoZoomEngine(config);
+        var recording = BuildRecordingWithClicks(10.0, []);
+        engine.BuildZoomTimeline(recording, W, H, TickFrequency);
+
+        engine.SetManualKeyframes([
+            new ZoomKeyframe
+            {
+                Timestamp = TimeSpan.FromSeconds(2.0),
+                ZoomLevel = 2.0,
+                CenterX = 0.3,
+                CenterY = 0.3,
+            },
+            new ZoomKeyframe
+            {
+                Timestamp = TimeSpan.FromSeconds(3.0),
+                ZoomLevel = 2.0,
+                CenterX = 0.7,
+                CenterY = 0.7,
+            },
+        ]);
+
+        // Step through and assert per-step center movement is bounded.
+        // With smoothed blending across a ~500ms overlap, peak rate is roughly
+        // (W * 0.4) / 0.5s ≈ 1.5 px/ms ≈ 8 px per 5ms linear, ~16 px with
+        // cubic-bezier ease. Pick 60 px as a generous-but-meaningful threshold
+        // — well below the old ~768 px hard-switch snap (B's center minus A's
+        // center across the crossover), while still catching any future
+        // regression that re-introduces a jump.
+        const double step = 0.005;
+        const float maxStepPixels = 60f;
+        float prevCx = -1, prevCy = -1;
+        for (double t = 2.0; t <= 3.6; t += step)
+        {
+            var state = engine.GetZoomState(t);
+            float cx = state.CenterX;
+            float cy = state.CenterY;
+            if (prevCx >= 0)
+            {
+                Assert.IsTrue(Math.Abs(cx - prevCx) < maxStepPixels,
+                    $"Center X jumped {Math.Abs(cx - prevCx):F1}px at t={t:F3}");
+                Assert.IsTrue(Math.Abs(cy - prevCy) < maxStepPixels,
+                    $"Center Y jumped {Math.Abs(cy - prevCy):F1}px at t={t:F3}");
+            }
+            prevCx = cx;
+            prevCy = cy;
+        }
+
+        // Endpoint assertions: outside the overlap, each keyframe should own
+        // the focal point — verifies the blend doesn't bias the result.
+        // At t = 2.0 (kf A's timestamp, hold phase, kf B not yet active),
+        // center must equal A's center.
+        var stateA = engine.GetZoomState(2.0);
+        Assert.AreEqual(0.3f * W, stateA.CenterX, 1f, "Center at A's timestamp should be A's center");
+        Assert.AreEqual(0.3f * H, stateA.CenterY, 1f, "Center at A's timestamp should be A's center");
+
+        // At t = 3.0 (kf B's timestamp, hold phase, kf A's post-ease finished
+        // at 2.0 + hold(0.575) + post(0.575) = 3.15 — A is still tailing off
+        // here, but B's weight at hold-peak dominates by ~3x). Use a looser
+        // tolerance reflecting the still-active tail.
+        var stateB = engine.GetZoomState(3.0);
+        Assert.IsTrue(stateB.CenterX > 0.55f * W,
+            $"Center at B's timestamp should be near B's center (0.7*W=1344), got {stateB.CenterX}");
+
+        // After both segments end (B's post-ease finishes at 3.0 + 0.575 + 0.575
+        // = 4.15), no manual override → falls through to auto (empty), so
+        // zoom returns to 1.0.
+        var stateAfter = engine.GetZoomState(4.5);
+        Assert.AreEqual(1.0f, stateAfter.ZoomLevel, 0.01f,
+            "Zoom should return to 1.0 after all segments end");
+    }
 }


### PR DESCRIPTION
When two manual zoom segments overlap, the prior max-zoom-wins strategy kept the zoom level continuous but picked the center wholesale from the winning segment, causing a visible snap of the focal point at the crossover (the moment B's zoom first exceeded A's). Editing a segment moved where this snap occurred, making it more noticeable.

Now both EvaluateManualKeyframes and EvaluateAutoSegments compute the center as a weighted average across all active segments using `w = max(0, zoom - 1)` per segment, while zoom level continues to use max. This makes the focal point glide smoothly from A's center to B's center across the overlap. Falls back to the max-zoom segment's center when all weights are ~0 (segment boundaries at exactly zoom == 1.0). For EvaluateManualKeyframes, `bestZoom` starts at -inf so the fallback captures the first active segment's center even at exact boundaries (guarded by the existing `!anyActive` early-return).

Added regression test `GetZoomState_OverlappingManualKeyframes_CenterDoesNotSnap` that steps through the overlap at 5 ms granularity and asserts per-step center delta stays below 60 px (vs. the ~768 px hard-switch snap), plus endpoint assertions for each segment's center and zoom returning to 1.0 after both end.

All 261 tests pass.