### PR TITLE
Expose style menu for full-screen captures

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -1335,27 +1335,27 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 
 ---
 
-## Region Selector Overlay & Recording Page — PR Review Fixes
+## Region Selector Overlay & Recording Page ï¿½ PR Review Fixes
 
 **Approaches tried:**
 
-1. **TryApplyPresetRegion coordinate space bug** — Was assigning CaptureRegion.X/Y/Width/Height (monitor-local DIPs) directly into overlay selection coords (virtual-desktop overlay DIPs). On multi-monitor / mixed-DPI this seeded the wrong place/size. Fixed by converting monitor-local DIPs ? physical pixels (using saved monitor's origin + GetMonitorDpiScale) ? overlay DIPs (subtract virtual-desktop origin from SM_X/YVIRTUALSCREEN, divide by _screenshotWidth/ActualWidth). ?
-2. **UpdateOverlay degenerate-selection state leak** — When sw/sh clamped to <=0, the blank overlay rendered but _hasSelection and ButtonPanel.Visibility were left set. Now clears _hasSelection/_sel* and hides ButtonPanel in the degenerate branch. ?
-3. **RecordingPage._infoBarTimer navigation leak** — Timer was created on the page's DispatcherQueue and retained OnInfoBarTimerTick, keeping the page alive after navigation. Now Stop() + detach Tick handler + close InfoBar in OnNavigatedFrom. ?
+1. **TryApplyPresetRegion coordinate space bug** ï¿½ Was assigning CaptureRegion.X/Y/Width/Height (monitor-local DIPs) directly into overlay selection coords (virtual-desktop overlay DIPs). On multi-monitor / mixed-DPI this seeded the wrong place/size. Fixed by converting monitor-local DIPs ? physical pixels (using saved monitor's origin + GetMonitorDpiScale) ? overlay DIPs (subtract virtual-desktop origin from SM_X/YVIRTUALSCREEN, divide by _screenshotWidth/ActualWidth). ?
+2. **UpdateOverlay degenerate-selection state leak** ï¿½ When sw/sh clamped to <=0, the blank overlay rendered but _hasSelection and ButtonPanel.Visibility were left set. Now clears _hasSelection/_sel* and hides ButtonPanel in the degenerate branch. ?
+3. **RecordingPage._infoBarTimer navigation leak** ï¿½ Timer was created on the page's DispatcherQueue and retained OnInfoBarTimerTick, keeping the page alive after navigation. Now Stop() + detach Tick handler + close InfoBar in OnNavigatedFrom. ?
 
 **What worked:** All three above.
 
 
 ---
 
-## Editor — Spacebar Play/Pause Shortcut
+## Editor ï¿½ Spacebar Play/Pause Shortcut
 
 **Feature/area:** EditorPage keyboard accelerators / Preview playback.
 
 **Approaches tried:**
 
-1. **Page-level `KeyboardAccelerator` with `Key="Space"` invoking `Preview.Play()`/`Preview.Pause()` based on `Preview.IsPlaying`** — Worked. ?
-2. **Skip handler when a text input has focus** — Used `FocusManager.GetFocusedElement(XamlRoot)` and bailed for `TextBox`/`PasswordBox`/`RichEditBox`/`AutoSuggestBox` so typing a space in editable fields isn't hijacked. ?
+1. **Page-level `KeyboardAccelerator` with `Key="Space"` invoking `Preview.Play()`/`Preview.Pause()` based on `Preview.IsPlaying`** ï¿½ Worked. ?
+2. **Skip handler when a text input has focus** ï¿½ Used `FocusManager.GetFocusedElement(XamlRoot)` and bailed for `TextBox`/`PasswordBox`/`RichEditBox`/`AutoSuggestBox` so typing a space in editable fields isn't hijacked. ?
 
 **What worked:** XAML accelerator + focus-check guard in the handler.
 
@@ -1363,9 +1363,9 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 
 ---
 
-## Overlapping Zoom Segments — Center Snap Fix
+## Overlapping Zoom Segments ï¿½ Center Snap Fix
 
-**Feature/area:** AutoZoomEngine — focal-point continuity across overlapping zoom segments
+**Feature/area:** AutoZoomEngine ï¿½ focal-point continuity across overlapping zoom segments
 
 **Approaches tried:**
 1. Earlier fix used max-zoom-wins for both zoom level and center (cx/cy). Zoom level stayed continuous, but the *center* snapped at the instant B's zoom first exceeded A's, since the winning keyframe's center was used wholesale. Editing a segment moved where this snap occurred, making the visual jump obvious.
@@ -1377,7 +1377,7 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 - Regression test `GetZoomState_OverlappingManualKeyframes_CenterDoesNotSnap` steps through the overlap and asserts per-step center delta stays well under the would-be snap magnitude.
 
 **What didn't work:**
-- Returning the max-zoom segment's center as-is — produces a discontinuous jump at the crossover when overlapping segments have different centers.
+- Returning the max-zoom segment's center as-is ï¿½ produces a discontinuous jump at the crossover when overlapping segments have different centers.
 
 ---
 
@@ -1387,9 +1387,9 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 
 **Approaches tried:**
 
-1. **Make StyleButton/StyleSeparator visible unconditionally in InitializeStyleControls** — Worked. Previously gated on Window/Region only; now exposed for Monitor too. âœ…
-2. **Gate the Monitor background-defaults override (Padding=0, CornerRadius=0, ShadowEnabled=false, BorderEnabled=false) behind a new `ProjectService.CompositionDefaultsApplied` flag reset in `SetProject`** — Worked. Defaults apply once per project load; user edits via the now-visible style menu survive editor re-navigation since `InitializePreviewAsync` runs on every page construction. âœ…
+1. **Make StyleButton/StyleSeparator visible unconditionally in InitializeStyleControls** ï¿½ Worked. Previously gated on Window/Region only; now exposed for Monitor too. âœ…
+2. **Move the Monitor background-defaults override (Padding=0, CornerRadius=0, ShadowEnabled=false, BorderEnabled=false) from `EditorPage.InitializePreviewAsync` into `ProjectService.SetProject`** ï¿½ Worked. Defaults apply at project-load time so user edits via the now-visible style menu survive editor re-navigation. âœ…
 
-**What worked:** Combination — unconditional style-menu visibility + one-shot defaults flag in `ProjectService` reset on `SetProject`.
+**What worked:** Combination ï¿½ unconditional style-menu visibility + applying Monitor defaults in `ProjectService.SetProject` (instead of every `InitializePreviewAsync`).
 
-**What didn't work:** Leaving the Monitor override unconditional in `InitializePreviewAsync` — would clobber user edits every time the EditorPage was re-constructed.
+**What didn't work:** Leaving the Monitor override unconditional in `InitializePreviewAsync` ï¿½ would clobber user edits every time the EditorPage was re-constructed.

--- a/learnings.md
+++ b/learnings.md
@@ -1378,3 +1378,18 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 
 **What didn't work:**
 - Returning the max-zoom segment's center as-is — produces a discontinuous jump at the crossover when overlapping segments have different centers.
+
+---
+
+## Style Menu For Full-Screen Capture
+
+**Feature/area:** EditorPage style flyout, ProjectService composition defaults.
+
+**Approaches tried:**
+
+1. **Make StyleButton/StyleSeparator visible unconditionally in InitializeStyleControls** — Worked. Previously gated on Window/Region only; now exposed for Monitor too. âœ…
+2. **Gate the Monitor background-defaults override (Padding=0, CornerRadius=0, ShadowEnabled=false, BorderEnabled=false) behind a new `ProjectService.CompositionDefaultsApplied` flag reset in `SetProject`** — Worked. Defaults apply once per project load; user edits via the now-visible style menu survive editor re-navigation since `InitializePreviewAsync` runs on every page construction. âœ…
+
+**What worked:** Combination — unconditional style-menu visibility + one-shot defaults flag in `ProjectService` reset on `SetProject`.
+
+**What didn't work:** Leaving the Monitor override unconditional in `InitializePreviewAsync` — would clobber user edits every time the EditorPage was re-constructed.

--- a/src/Musio.App/Pages/EditorPage.xaml.cs
+++ b/src/Musio.App/Pages/EditorPage.xaml.cs
@@ -1878,7 +1878,7 @@ public sealed partial class EditorPage : Page
     private void InitializeStyleControls(Project project, CompositionConfig config)
     {
         // Style menu is available for all capture types. Monitor (full-screen)
-        // captures start with zeroed defaults (see InitializePreviewAsync) but
+        // captures start with zeroed defaults (see ProjectService.SetProject) but
         // users can still customize padding, corner radius, shadow, border, etc.
         StyleButton.Visibility = Visibility.Visible;
         StyleSeparator.Visibility = Visibility.Visible;

--- a/src/Musio.App/Pages/EditorPage.xaml.cs
+++ b/src/Musio.App/Pages/EditorPage.xaml.cs
@@ -333,21 +333,10 @@ public sealed partial class EditorPage : Page
             Zoom = new AutoZoomConfig { Enabled = true },
         };
 
-        // Only apply background fill for window and region captures —
-        // full-screen (monitor) recordings render without padding/shadow.
-        if (project.CaptureType is CaptureTargetType.Monitor)
-        {
-            config = config with
-            {
-                Background = config.Background with
-                {
-                    Padding = 0,
-                    ShadowEnabled = false,
-                    CornerRadius = 0,
-                    BorderEnabled = false,
-                },
-            };
-        }
+        // Capture-type-specific style defaults (e.g. zeroed padding/shadow
+        // for full-screen Monitor captures) are applied once at project load
+        // time in ProjectService.SetProject. User edits via the Style menu
+        // are preserved across editor re-navigation.
 
         // Auto-enable webcam overlay if the project has a webcam recording
         if (!string.IsNullOrWhiteSpace(project.WebcamFilePath) &&
@@ -1888,12 +1877,11 @@ public sealed partial class EditorPage : Page
 
     private void InitializeStyleControls(Project project, CompositionConfig config)
     {
-        bool showStyle = project.CaptureType is CaptureTargetType.Window or CaptureTargetType.Region;
-        var vis = showStyle ? Visibility.Visible : Visibility.Collapsed;
-        StyleButton.Visibility = vis;
-        StyleSeparator.Visibility = vis;
-
-        if (!showStyle) return;
+        // Style menu is available for all capture types. Monitor (full-screen)
+        // captures start with zeroed defaults (see InitializePreviewAsync) but
+        // users can still customize padding, corner radius, shadow, border, etc.
+        StyleButton.Visibility = Visibility.Visible;
+        StyleSeparator.Visibility = Visibility.Visible;
 
         // Populate preset combo with built-in presets
         PresetCombo.Items.Clear();

--- a/src/Musio.App/Services/ProjectService.cs
+++ b/src/Musio.App/Services/ProjectService.cs
@@ -1,3 +1,4 @@
+using Musio.Core.Capture;
 using Musio.Core.Models;
 using Musio.Core.Processing;
 using Musio.Core.Timeline;
@@ -28,6 +29,27 @@ public class ProjectService
             TrimEnd = project.Duration,
             Fps = project.Fps
         };
+
+        // Apply capture-type-specific style defaults at project load time
+        // so they're guaranteed to be in place before the editor reads
+        // composition state, regardless of which initialization path runs.
+        // Full-screen (Monitor) captures default to zeroed padding/shadow/
+        // corner radius/border; users can still override via the Style menu
+        // and their edits persist for the lifetime of this project.
+        if (project.CaptureType is CaptureTargetType.Monitor)
+        {
+            CurrentComposition = CurrentComposition with
+            {
+                Background = CurrentComposition.Background with
+                {
+                    Padding = 0,
+                    ShadowEnabled = false,
+                    CornerRadius = 0,
+                    BorderEnabled = false,
+                },
+            };
+        }
+
         ProjectChanged?.Invoke(this, EventArgs.Empty);
     }
 }


### PR DESCRIPTION
Make the StyleButton flyout visible for all capture types (previously Window/Region only) so users can customize padding, corner radius, shadow, and border on full-screen Monitor recordings.

Move the Monitor zeroed-defaults override (Padding=0, CornerRadius=0, ShadowEnabled=false, BorderEnabled=false) from EditorPage.InitializePreviewAsync into ProjectService.SetProject. Defaults are now applied exactly once at project-load time, before any editor initialization path runs, so user edits via the Style menu persist across editor re-navigation.