### PR TITLE
Polish recording overlay: acrylic backdrop, themed stop button, ticke…

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -1665,3 +1665,18 @@ the success message. Resetting on close is cleaner and matches user intent.
 - Swatch endpoint math vs compositor parity: the swatch clips at the unit-square edge while `BackgroundCompositor` uses half-diagonal endpoints. The preview direction is correct; saturation differs slightly at non-orthogonal angles. Acceptable for a small swatch.
 
 ---
+
+---
+
+## Recording Overlay - System Backdrop Acrylic & Matching Shadow
+
+**Feature/area:** `RecordingOverlayWindow`
+
+**Approaches tried:**
+
+1. **`AcrylicBrush` on Grid + `SetWindowRgn` pill clip** - Worked for the body, but DWM's drop shadow still followed the rectangular window bounds, so the shadow appeared square around a rounded body.
+2. **Switched to `SystemBackdrop = new DesktopAcrylicBackdrop()` and removed `SetWindowRgn` + Grid `CornerRadius`** - Worked. The window itself is acrylic, DWM rounds the corners via `DWMWA_WINDOW_CORNER_PREFERENCE = DWMWCP_ROUND` (~8px), and the DWM shadow now follows those rounded corners. Grid background is `Transparent`. Guarded with `DesktopAcrylicController.IsSupported()`.
+
+**What worked:** `DesktopAcrylicBackdrop` (Microsoft.UI.Xaml.Media) as the window backdrop with default DWM corner rounding; removed the GDI region clip that decoupled the body from the shadow.
+
+**What didn't work:** `SetWindowRgn` for a full pill shape - it clips only the window contents, not the DWM shadow, so the shadow stayed rectangular.

--- a/src/Musio.App/RecordingOverlayWindow.xaml
+++ b/src/Musio.App/RecordingOverlayWindow.xaml
@@ -8,7 +8,7 @@
     <Grid x:Name="RootGrid" Padding="16,8,8,8"
           Background="Transparent">
 
-        <!-- Recording state: indicator dot + elapsed time + stop button -->
+        <!-- Recording state: elapsed time + stop button -->
         <StackPanel x:Name="RecordingPanel" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center" HorizontalAlignment="Left">
             <TextBlock
                 x:Name="ElapsedText"

--- a/src/Musio.App/RecordingOverlayWindow.xaml
+++ b/src/Musio.App/RecordingOverlayWindow.xaml
@@ -5,22 +5,16 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Musio Recording">
 
-    <Grid Padding="14,8" CornerRadius="26"
-          Background="{ThemeResource RecordingOverlayBackgroundBrush}">
+    <Grid x:Name="RootGrid" Padding="16,8,8,8"
+          Background="Transparent">
 
         <!-- Recording state: indicator dot + elapsed time + stop button -->
         <StackPanel x:Name="RecordingPanel" Orientation="Horizontal" Spacing="12" VerticalAlignment="Center" HorizontalAlignment="Left">
-            <Ellipse
-                Width="10"
-                Height="10"
-                Fill="{ThemeResource RecordingIndicatorBrush}"
-                VerticalAlignment="Center" />
-
             <TextBlock
                 x:Name="ElapsedText"
                 Text="00:00"
                 Foreground="{ThemeResource OverlayForegroundBrush}"
-                FontSize="15"
+                FontSize="18"
                 FontWeight="SemiBold"
                 FontFamily="Consolas"
                 VerticalAlignment="Center"
@@ -32,27 +26,64 @@
             Click="Stop_Click"
             Width="32"
             Height="32"
-            CornerRadius="16"
+            CornerRadius="8"
             Padding="0"
-            Background="{ThemeResource RecordingStopBackgroundBrush}"
-            BorderBrush="{ThemeResource RecordingStopBorderBrush}"
+            Background="{ThemeResource RecordingStopRestBrush}"
+            BorderBrush="{ThemeResource RecordingStopRestBrush}"
+            Foreground="{ThemeResource RecordingStopForegroundBrush}"
             HorizontalAlignment="Right"
             VerticalAlignment="Center"
-            ToolTipService.ToolTip="Stop recording">
-            <FontIcon Glyph="&#xE71A;" FontSize="12" Foreground="{ThemeResource RecordingIndicatorBrush}" />
+            ToolTipService.ToolTip="Stop recording"
+            AutomationProperties.Name="Stop recording">
+            <Button.Resources>
+                <!-- Hover: brighter red for clear feedback -->
+                <StaticResource x:Key="ButtonBackgroundPointerOver"  ResourceKey="RecordingStopHoverBrush" />
+                <StaticResource x:Key="ButtonBorderBrushPointerOver" ResourceKey="RecordingStopHoverBrush" />
+                <StaticResource x:Key="ButtonForegroundPointerOver"  ResourceKey="RecordingStopForegroundBrush" />
+                <!-- Pressed: darker red to signal the press -->
+                <StaticResource x:Key="ButtonBackgroundPressed"  ResourceKey="RecordingStopPressedBrush" />
+                <StaticResource x:Key="ButtonBorderBrushPressed" ResourceKey="RecordingStopPressedBrush" />
+                <StaticResource x:Key="ButtonForegroundPressed"  ResourceKey="RecordingStopForegroundBrush" />
+            </Button.Resources>
+            <FontIcon Glyph="&#xE71A;" FontSize="12" />
         </Button>
 
         <!-- Stopping state: text left-aligned (where timer was), spinner right-aligned (where stop button was) -->
-        <TextBlock
-            x:Name="StoppingText"
-            Text="Engaging…"
-            Foreground="{ThemeResource OverlayForegroundBrush}"
-            FontSize="14"
-            FontWeight="SemiBold"
+        <Grid
+            x:Name="StoppingTextHost"
+            Width="160"
+            Height="22"
             HorizontalAlignment="Left"
             VerticalAlignment="Center"
             Margin="4,0,0,0"
-            Visibility="Collapsed" />
+            Visibility="Collapsed">
+            <Grid.Clip>
+                <RectangleGeometry Rect="0,0,160,22" />
+            </Grid.Clip>
+            <TextBlock
+                x:Name="StoppingTextA"
+                Foreground="{ThemeResource OverlayForegroundBrush}"
+                FontSize="16"
+                FontWeight="SemiBold"
+                VerticalAlignment="Center"
+                RenderTransformOrigin="0,0.5">
+                <TextBlock.RenderTransform>
+                    <TranslateTransform x:Name="StoppingTextATranslate" Y="0" />
+                </TextBlock.RenderTransform>
+            </TextBlock>
+            <TextBlock
+                x:Name="StoppingTextB"
+                Foreground="{ThemeResource OverlayForegroundBrush}"
+                FontSize="16"
+                FontWeight="SemiBold"
+                VerticalAlignment="Center"
+                Opacity="0"
+                RenderTransformOrigin="0,0.5">
+                <TextBlock.RenderTransform>
+                    <TranslateTransform x:Name="StoppingTextBTranslate" Y="22" />
+                </TextBlock.RenderTransform>
+            </TextBlock>
+        </Grid>
         <ProgressRing
             x:Name="StoppingSpinner"
             Width="18" Height="18"
@@ -60,6 +91,7 @@
             Foreground="{ThemeResource OverlayForegroundBrush}"
             HorizontalAlignment="Right"
             VerticalAlignment="Center"
+            Margin="0,0,7,0"
             Visibility="Collapsed" />
     </Grid>
 </Window>

--- a/src/Musio.App/RecordingOverlayWindow.xaml.cs
+++ b/src/Musio.App/RecordingOverlayWindow.xaml.cs
@@ -51,7 +51,7 @@ public sealed partial class RecordingOverlayWindow : Window
         }
         else
         {
-            RootGrid.Background = (Brush)Application.Current.Resources["RecordingOverlayBackgroundBrush"];
+            RootGrid.Background = (Brush)Application.Current.Resources["RecordingOverlaySolidBackgroundBrush"];
         }
 
         // Show initial elapsed time
@@ -251,13 +251,13 @@ public sealed partial class RecordingOverlayWindow : Window
         Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTargetProperty(inOp, "Opacity");
         sb.Children.Add(inOp);
 
-        sb.Begin();
         _currentPhraseStoryboard?.Stop();
         _currentPhraseStoryboard = sb;
         sb.Completed += (_, _) =>
         {
             if (ReferenceEquals(_currentPhraseStoryboard, sb)) _currentPhraseStoryboard = null;
         };
+        sb.Begin();
         _showingA = !_showingA;
     }
 

--- a/src/Musio.App/RecordingOverlayWindow.xaml.cs
+++ b/src/Musio.App/RecordingOverlayWindow.xaml.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
 using Musio_App.ViewModels;
 using Windows.Graphics;
 
@@ -15,6 +17,8 @@ public sealed partial class RecordingOverlayWindow : Window
 {
     private readonly RecordingViewModel _viewModel;
     private bool _isClosingProgrammatically;
+    private bool _stopRequested;
+    private Microsoft.UI.Xaml.Media.Animation.Storyboard? _currentPhraseStoryboard;
 
     private static readonly string[] StoppingPhrases =
     [
@@ -37,6 +41,18 @@ public sealed partial class RecordingOverlayWindow : Window
     {
         _viewModel = viewModel;
         InitializeComponent();
+
+        // Use system desktop acrylic for the window backdrop so DWM-drawn shadow
+        // follows the rounded corners of the window. Fall back to a solid theme
+        // brush on systems where acrylic is unsupported (e.g., remote sessions).
+        if (DesktopAcrylicController.IsSupported())
+        {
+            SystemBackdrop = new DesktopAcrylicBackdrop();
+        }
+        else
+        {
+            RootGrid.Background = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["RecordingOverlayBackgroundBrush"];
+        }
 
         // Show initial elapsed time
         ElapsedText.Text = _viewModel.ElapsedTime;
@@ -83,14 +99,9 @@ public sealed partial class RecordingOverlayWindow : Window
         // Size the overlay(device pixels, scaled for DPI)
         var dpi = GetDpiForWindow(hwnd);
         var scale = dpi / 96.0;
-        int width = (int)(240 * scale);
+        int width = (int)(200 * scale);
         int height = (int)(52 * scale);
         AppWindow.Resize(new SizeInt32(width, height));
-
-        // Clip the window to a pill-shaped region so the black window background
-        // doesn't peek out behind the rounded Grid content
-        var region = CreateRoundRectRgn(0, 0, width + 1, height + 1, height, height);
-        SetWindowRgn(hwnd, region, true);
 
         // Position at bottom-right of primary monitor work area
         PositionBottomRight(width, height);
@@ -132,6 +143,8 @@ public sealed partial class RecordingOverlayWindow : Window
     {
         try
         {
+            if (_stopRequested) return;
+            _stopRequested = true;
             _viewModel.NotifyStopRequested();
             StopButton.IsEnabled = false;
             ShowStoppingState();
@@ -152,21 +165,100 @@ public sealed partial class RecordingOverlayWindow : Window
         // Swap to the stopping UI
         RecordingPanel.Visibility = Visibility.Collapsed;
         StopButton.Visibility = Visibility.Collapsed;
-        StoppingText.Visibility = Visibility.Visible;
+        StoppingTextHost.Visibility = Visibility.Visible;
         StoppingSpinner.Visibility = Visibility.Visible;
 
         _phraseTimer?.Stop();
 
-        // Cycle through phrases
+        // Cycle through phrases with a vertical flip-ticker animation
         _phraseIndex = 0;
-        StoppingText.Text = StoppingPhrases[0];
-        _phraseTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1.5) };
+        _showingA = true;
+        StoppingTextA.Text = StoppingPhrases[0];
+        StoppingTextA.Opacity = 1;
+        StoppingTextATranslate.Y = 0;
+        StoppingTextB.Opacity = 0;
+        StoppingTextBTranslate.Y = StoppingTextHost.Height;
+
+        _phraseTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2) };
         _phraseTimer.Tick += (_, _) =>
         {
             _phraseIndex = (_phraseIndex + 1) % StoppingPhrases.Length;
-            StoppingText.Text = StoppingPhrases[_phraseIndex];
+            AnimateToPhrase(StoppingPhrases[_phraseIndex]);
         };
         _phraseTimer.Start();
+    }
+
+    private bool _showingA = true;
+
+    private void AnimateToPhrase(string newPhrase)
+    {
+        double height = StoppingTextHost.Height;
+        var outgoing = _showingA ? StoppingTextA : StoppingTextB;
+        var incoming = _showingA ? StoppingTextB : StoppingTextA;
+        var outgoingTranslate = _showingA ? StoppingTextATranslate : StoppingTextBTranslate;
+        var incomingTranslate = _showingA ? StoppingTextBTranslate : StoppingTextATranslate;
+
+        // Pre-position the incoming text below the host and set its content
+        incoming.Text = newPhrase;
+        incoming.Opacity = 0;
+        incomingTranslate.Y = height;
+
+        var duration = TimeSpan.FromMilliseconds(350);
+        var easing = new Microsoft.UI.Xaml.Media.Animation.CubicEase
+        {
+            EasingMode = Microsoft.UI.Xaml.Media.Animation.EasingMode.EaseInOut,
+        };
+
+        var sb = new Microsoft.UI.Xaml.Media.Animation.Storyboard();
+
+        // Outgoing: slide up + fade out
+        var outY = new Microsoft.UI.Xaml.Media.Animation.DoubleAnimation
+        {
+            To = -height,
+            Duration = duration,
+            EasingFunction = easing,
+        };
+        Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTarget(outY, outgoingTranslate);
+        Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTargetProperty(outY, "Y");
+        sb.Children.Add(outY);
+
+        var outOp = new Microsoft.UI.Xaml.Media.Animation.DoubleAnimation
+        {
+            To = 0,
+            Duration = duration,
+        };
+        Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTarget(outOp, outgoing);
+        Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTargetProperty(outOp, "Opacity");
+        sb.Children.Add(outOp);
+
+        // Incoming: slide up from below + fade in
+        var inY = new Microsoft.UI.Xaml.Media.Animation.DoubleAnimation
+        {
+            To = 0,
+            Duration = duration,
+            EasingFunction = easing,
+        };
+        Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTarget(inY, incomingTranslate);
+        Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTargetProperty(inY, "Y");
+        sb.Children.Add(inY);
+
+        var inOp = new Microsoft.UI.Xaml.Media.Animation.DoubleAnimation
+        {
+            To = 1,
+            Duration = duration,
+        };
+        Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTarget(inOp, incoming);
+        Microsoft.UI.Xaml.Media.Animation.Storyboard.SetTargetProperty(inOp, "Opacity");
+        sb.Children.Add(inOp);
+
+        sb.Begin();
+        _currentPhraseStoryboard?.Stop();
+        _currentPhraseStoryboard = sb;
+        sb.Completed += (_, _) =>
+        {
+            if (ReferenceEquals(_currentPhraseStoryboard, sb)) _currentPhraseStoryboard = null;
+        };
+        _showingA = !_showingA;
     }
 
     private async void OnOverlayClosing(AppWindow sender, AppWindowClosingEventArgs args)
@@ -175,8 +267,10 @@ public sealed partial class RecordingOverlayWindow : Window
         {
             if (!_isClosingProgrammatically)
             {
-                _viewModel.NotifyStopRequested();
                 args.Cancel = true;
+                if (_stopRequested) return;
+                _stopRequested = true;
+                _viewModel.NotifyStopRequested();
                 ShowStoppingState();
                 await Task.Delay(50);
                 StopRequested?.Invoke(this, EventArgs.Empty);
@@ -196,6 +290,8 @@ public sealed partial class RecordingOverlayWindow : Window
     {
         _phraseTimer?.Stop();
         _phraseTimer = null;
+        _currentPhraseStoryboard?.Stop();
+        _currentPhraseStoryboard = null;
         _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
         _isClosingProgrammatically = true;
         try { Close(); }
@@ -226,10 +322,4 @@ public sealed partial class RecordingOverlayWindow : Window
 
     [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW")]
     private static extern int SetWindowLong(IntPtr hwnd, int nIndex, int dwNewLong);
-
-    [DllImport("gdi32.dll")]
-    private static extern IntPtr CreateRoundRectRgn(int x1, int y1, int x2, int y2, int cx, int cy);
-
-    [DllImport("user32.dll")]
-    private static extern int SetWindowRgn(IntPtr hwnd, IntPtr hRgn, bool bRedraw);
 }

--- a/src/Musio.App/RecordingOverlayWindow.xaml.cs
+++ b/src/Musio.App/RecordingOverlayWindow.xaml.cs
@@ -51,7 +51,7 @@ public sealed partial class RecordingOverlayWindow : Window
         }
         else
         {
-            RootGrid.Background = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["RecordingOverlayBackgroundBrush"];
+            RootGrid.Background = (Brush)Application.Current.Resources["RecordingOverlayBackgroundBrush"];
         }
 
         // Show initial elapsed time

--- a/src/Musio.App/Themes/AppColors.xaml
+++ b/src/Musio.App/Themes/AppColors.xaml
@@ -38,6 +38,7 @@
             <AcrylicBrush x:Key="RecordingOverlayBackgroundBrush"
                           TintColor="#1E1E1E" TintOpacity="0.8"
                           FallbackColor="#E01E1E1E" />
+            <SolidColorBrush x:Key="RecordingOverlaySolidBackgroundBrush" Color="#E01E1E1E" />
             <SolidColorBrush x:Key="RecordingIndicatorBrush"       Color="#FFFF3B30" />
             <SolidColorBrush x:Key="RecordingStopRestBrush"        Color="#FFD13438" />
             <SolidColorBrush x:Key="RecordingStopHoverBrush"       Color="#FFE74C3C" />
@@ -77,6 +78,7 @@
             <AcrylicBrush x:Key="RecordingOverlayBackgroundBrush"
                           TintColor="#F0F0F0" TintOpacity="0.8"
                           FallbackColor="#E0F0F0F0" />
+            <SolidColorBrush x:Key="RecordingOverlaySolidBackgroundBrush" Color="#E0F0F0F0" />
             <SolidColorBrush x:Key="RecordingIndicatorBrush"       Color="#FFFF3B30" />
             <SolidColorBrush x:Key="RecordingStopRestBrush"        Color="#FFC42B1C" />
             <SolidColorBrush x:Key="RecordingStopHoverBrush"       Color="#FFD13438" />
@@ -114,6 +116,7 @@
 
             <!-- ── Recording overlay ── -->
             <SolidColorBrush x:Key="RecordingOverlayBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
+            <SolidColorBrush x:Key="RecordingOverlaySolidBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="RecordingIndicatorBrush"       Color="{StaticResource SystemColorHotlightColor}" />
             <SolidColorBrush x:Key="RecordingStopRestBrush"        Color="{StaticResource SystemColorHotlightColor}" />
             <SolidColorBrush x:Key="RecordingStopHoverBrush"       Color="{StaticResource SystemColorHighlightColor}" />

--- a/src/Musio.App/Themes/AppColors.xaml
+++ b/src/Musio.App/Themes/AppColors.xaml
@@ -39,8 +39,10 @@
                           TintColor="#1E1E1E" TintOpacity="0.8"
                           FallbackColor="#E01E1E1E" />
             <SolidColorBrush x:Key="RecordingIndicatorBrush"       Color="#FFFF3B30" />
-            <SolidColorBrush x:Key="RecordingStopBackgroundBrush"  Color="#40FF3B30" />
-            <SolidColorBrush x:Key="RecordingStopBorderBrush"      Color="#60FF3B30" />
+            <SolidColorBrush x:Key="RecordingStopRestBrush"        Color="#FFD13438" />
+            <SolidColorBrush x:Key="RecordingStopHoverBrush"       Color="#FFE74C3C" />
+            <SolidColorBrush x:Key="RecordingStopPressedBrush"     Color="#FFA12F32" />
+            <SolidColorBrush x:Key="RecordingStopForegroundBrush"  Color="#FFFFFFFF" />
         </ResourceDictionary>
 
         <!-- ═══════════════════════════════════════════════════════════════
@@ -76,8 +78,10 @@
                           TintColor="#F0F0F0" TintOpacity="0.8"
                           FallbackColor="#E0F0F0F0" />
             <SolidColorBrush x:Key="RecordingIndicatorBrush"       Color="#FFFF3B30" />
-            <SolidColorBrush x:Key="RecordingStopBackgroundBrush"  Color="#40FF3B30" />
-            <SolidColorBrush x:Key="RecordingStopBorderBrush"      Color="#60FF3B30" />
+            <SolidColorBrush x:Key="RecordingStopRestBrush"        Color="#FFC42B1C" />
+            <SolidColorBrush x:Key="RecordingStopHoverBrush"       Color="#FFD13438" />
+            <SolidColorBrush x:Key="RecordingStopPressedBrush"     Color="#FF8B1F15" />
+            <SolidColorBrush x:Key="RecordingStopForegroundBrush"  Color="#FFFFFFFF" />
         </ResourceDictionary>
 
         <!-- ═══════════════════════════════════════════════════════════════
@@ -111,8 +115,10 @@
             <!-- ── Recording overlay ── -->
             <SolidColorBrush x:Key="RecordingOverlayBackgroundBrush" Color="{StaticResource SystemColorWindowColor}" />
             <SolidColorBrush x:Key="RecordingIndicatorBrush"       Color="{StaticResource SystemColorHotlightColor}" />
-            <SolidColorBrush x:Key="RecordingStopBackgroundBrush"  Color="{StaticResource SystemColorButtonFaceColor}" />
-            <SolidColorBrush x:Key="RecordingStopBorderBrush"      Color="{StaticResource SystemColorWindowTextColor}" />
+            <SolidColorBrush x:Key="RecordingStopRestBrush"        Color="{StaticResource SystemColorHotlightColor}" />
+            <SolidColorBrush x:Key="RecordingStopHoverBrush"       Color="{StaticResource SystemColorHighlightColor}" />
+            <SolidColorBrush x:Key="RecordingStopPressedBrush"     Color="{StaticResource SystemColorHotlightColor}" />
+            <SolidColorBrush x:Key="RecordingStopForegroundBrush"  Color="{StaticResource SystemColorHighlightTextColor}" />
         </ResourceDictionary>
 
     </ResourceDictionary.ThemeDictionaries>


### PR DESCRIPTION
- Switch overlay to DesktopAcrylicBackdrop so DWM shadow follows rounded corners; fall back to themed solid brush when acrylic unsupported.
- Replace pill SetWindowRgn clip with default DWM rounding.
- Theme-aware red stop button (rest/hover/press brushes) with filled style and RecordingStopForegroundBrush for HC contrast.
- Center spinner via right margin.
- Airport-ticker phrase animation: two TextBlocks with TranslateTransforms slide up/fade through a clipped host.
- Track current Storyboard and stop it on reset/close to avoid orphans.
- Reentrancy guard so Stop button + window close don't double-fire StopRequested.
- AutomationProperties.Name on stop button for screen readers.