### PR TITLE
Fix window-selector highlight to match visible window bounds

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -1680,3 +1680,21 @@ the success message. Resetting on close is cleaner and matches user intent.
 **What worked:** `DesktopAcrylicBackdrop` (Microsoft.UI.Xaml.Media) as the window backdrop with default DWM corner rounding; removed the GDI region clip that decoupled the body from the shadow.
 
 **What didn't work:** `SetWindowRgn` for a full pill shape - it clips only the window contents, not the DWM shadow, so the shadow stayed rectangular.
+
+## Window selection highlight rect overstating bounds (2026-05-24)
+
+**Feature/area**: WindowSelectorOverlay / RegionSelector
+
+**Problem**: Highlight rect during window-picker hover extended ~7px beyond the visible window edges, creating confusion about whether the recording would include the extra region.
+
+**Root cause**: GetWindowRect on Windows 10/11 includes the invisible DWM resize/shadow border for thick-framed windows. GraphicsCaptureItem.CreateForWindow captures roughly the visible bounds, so the highlight overstated the recorded area.
+
+**Fix that worked**: Replaced GetWindowRect with DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS) (with GetWindowRect fallback for non-DWM/classic-themed cases). Applied in WindowSelectorOverlay.EnumerateWindows() and RegionSelector.BuildWindowInfo(). Added a DwmGetWindowAttributeRect P/Invoke overload returning a RECT struct.
+
+## Region capture off-by-1px at fractional DPI — DID NOT WORK (2026-05-24)
+
+**Feature/area**: RegionSelectorOverlay / CaptureRegion / RecordingSession
+
+**Problem**: Precisely-selected region captures included an extra 1px on the left/top edge.
+
+**Approach tried (reverted)**: Hypothesized the cause was DIP↔physical-pixel round-trip rounding at fractional DPI. Extended `CaptureRegion` with optional `PixelX/Y/Width/Height`, threaded a `CropIsPhysicalPixels` flag through `CaptureTarget`, and skipped the DPI multiply in `RecordingSession`. **User confirmed this did not fix the 1px offset**, so the changes were reverted. The actual cause lies elsewhere (possibly in selection overlay rendering, stroke alignment, screenshot/Image stretch mapping, or the captured frame origin itself). Investigate before re-attempting.

--- a/src/Musio.App/Controls/WindowSelectorOverlay.xaml
+++ b/src/Musio.App/Controls/WindowSelectorOverlay.xaml
@@ -36,7 +36,9 @@
                 x:Name="HighlightRect"
                 Fill="Transparent"
                 Stroke="{ThemeResource OverlayForegroundBrush}"
-                StrokeThickness="2"
+                StrokeThickness="1"
+                RadiusX="8"
+                RadiusY="8"
                 Visibility="Collapsed" />
 
             <!-- Window info label -->

--- a/src/Musio.App/Controls/WindowSelectorOverlay.xaml.cs
+++ b/src/Musio.App/Controls/WindowSelectorOverlay.xaml.cs
@@ -159,7 +159,7 @@ public sealed partial class WindowSelectorOverlay : UserControl
             DwmGetWindowAttribute(hwnd, DWMWA_CLOAKED, out int cloaked, sizeof(int));
             if (cloaked != 0) return true;
 
-            if (!GetWindowRect(hwnd, out var rect)) return true;
+            if (!TryGetVisibleBounds(hwnd, out var rect)) return true;
             int w = rect.Right - rect.Left;
             int h = rect.Bottom - rect.Top;
             if (w <= 0 || h <= 0) return true;
@@ -455,6 +455,22 @@ public sealed partial class WindowSelectorOverlay : UserControl
 
     #endregion
 
+    /// <summary>
+    /// Returns the window's visible bounds using DWM extended frame bounds when available,
+    /// which excludes the invisible resize border that <see cref="GetWindowRect"/> includes.
+    /// This matches what Windows Graphics Capture actually records for the window.
+    /// </summary>
+    private static bool TryGetVisibleBounds(IntPtr hwnd, out RECT rect)
+    {
+        if (DwmGetWindowAttributeRect(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS,
+                out rect, Marshal.SizeOf<RECT>()) == 0 &&
+            rect.Right > rect.Left && rect.Bottom > rect.Top)
+        {
+            return true;
+        }
+        return GetWindowRect(hwnd, out rect);
+    }
+
     #region P/Invoke
 
     private const int SW_MINIMIZE = 6;
@@ -467,6 +483,7 @@ public sealed partial class WindowSelectorOverlay : UserControl
     private const int GWL_EXSTYLE = -20;
     private const int WS_EX_TOOLWINDOW = 0x00000080;
     private const int DWMWA_CLOAKED = 14;
+    private const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
 
     private const int WH_KEYBOARD_LL = 13;
     private static readonly IntPtr WM_KEYDOWN = 0x0100;
@@ -526,6 +543,9 @@ public sealed partial class WindowSelectorOverlay : UserControl
 
     [DllImport("dwmapi.dll")]
     private static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out int pvAttribute, int cbAttribute);
+
+    [DllImport("dwmapi.dll", EntryPoint = "DwmGetWindowAttribute")]
+    private static extern int DwmGetWindowAttributeRect(IntPtr hwnd, int dwAttribute, out RECT pvAttribute, int cbAttribute);
 
     [DllImport("user32.dll")]
     private static extern IntPtr GetDC(IntPtr hwnd);

--- a/src/Musio.Core/Capture/RegionSelector.cs
+++ b/src/Musio.Core/Capture/RegionSelector.cs
@@ -104,7 +104,7 @@ public class RegionSelector
     {
         try
         {
-            if (!GetWindowRect(hwnd, out var rect))
+            if (!TryGetVisibleBounds(hwnd, out var rect))
                 return null;
 
             var titleBuffer = new char[256];
@@ -144,9 +144,26 @@ public class RegionSelector
         }
     }
 
+    /// <summary>
+    /// Returns the window's visible bounds using DWM extended frame bounds when available,
+    /// which excludes the invisible resize border that <see cref="GetWindowRect"/> includes.
+    /// This matches what Windows Graphics Capture actually records for the window.
+    /// </summary>
+    private static bool TryGetVisibleBounds(IntPtr hwnd, out RECT rect)
+    {
+        if (DwmGetWindowAttributeRect(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS,
+                out rect, Marshal.SizeOf<RECT>()) == 0 &&
+            rect.Right > rect.Left && rect.Bottom > rect.Top)
+        {
+            return true;
+        }
+        return GetWindowRect(hwnd, out rect);
+    }
+
     #region P/Invoke declarations
 
     private const uint MONITORINFOF_PRIMARY = 1;
+    private const int DWMWA_EXTENDED_FRAME_BOUNDS = 9;
 
     private delegate bool MonitorEnumProc(
         IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData);
@@ -197,6 +214,9 @@ public class RegionSelector
 
     [DllImport("user32.dll")]
     private static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
+
+    [DllImport("dwmapi.dll", EntryPoint = "DwmGetWindowAttribute")]
+    private static extern int DwmGetWindowAttributeRect(IntPtr hwnd, int dwAttribute, out RECT pvAttribute, int cbAttribute);
 
     #endregion
 }


### PR DESCRIPTION
Use DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS) instead of GetWindowRect so the picker's highlight rect aligns with the visible window edges (and with what Windows Graphics Capture actually records), rather than extending into the invisible DWM resize/shadow border.

Also style the highlight to match the Windows 11 window contour: 1px stroke and 8px rounded corners.

Applied in WindowSelectorOverlay (overlay enumeration) and RegionSelector (BuildWindowInfo) for consistency, with a GetWindowRect fallback for non-DWM/classic-themed windows.