### PR TITLE
Crash/freeze hardening pass for high-DPI and high-resolution devices

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -1259,26 +1259,26 @@ This file tracks approaches tried, what worked, and what didn't for each feature
   - Match monitor by exact `DisplayName == MonitorId` (or `StartsWith(MonitorId + ' ')` to cover `"\\.\DISPLAY1 (Primary)"`). `Contains` matched `\\.\DISPLAY1` against `\\.\DISPLAY10`.
   - Round border px/py with `Math.Round` and floor pw/ph to even numbers (`& ~1`) to match the H.264 crop math in `RecordingSession` (avoids 1-2 px drift between highlight and actual captured frame).
 - **What didn't work**:
-  - `presenter.Maximize()` to cover the virtual desktop � only covers the monitor that owns the window. Use `AppWindow.MoveAndResize` with `SM_X/Y/CX/CYVIRTUALSCREEN`.
-  - `DisplayName.Contains(MonitorId)` for monitor lookup � unsafe substring match across DISPLAY1/DISPLAY10.
+  - `presenter.Maximize()` to cover the virtual desktop - only covers the monitor that owns the window. Use `AppWindow.MoveAndResize` with `SM_X/Y/CX/CYVIRTUALSCREEN`.
+  - `DisplayName.Contains(MonitorId)` for monitor lookup - unsafe substring match across DISPLAY1/DISPLAY10.
 
-## Stale Saved Region � Disconnected Monitor
+## Stale Saved Region - Disconnected Monitor
 
 - **Feature/area**: `RecordingViewModel.GetCaptureTarget` (CustomRegion mode).
-- **What worked**: When the saved `CaptureRegion.MonitorId` no longer matches any connected monitor, clear `SelectedRegion`/`HasSelectedRegion`, surface `RecordingStatus` ('Saved region's monitor is no longer connected � please select a new region'), and return null. This forces the user to reselect on the current display topology.
-- **What didn't work**: Silently falling back to `allMonitors.FirstOrDefault()` � the region's monitor-local DIPs got applied to the wrong (primary) monitor, producing a clamped/off-screen capture and a misplaced red border.
-## Region Picker � "blank on open / silent on cancel" confusion
+- **What worked**: When the saved `CaptureRegion.MonitorId` no longer matches any connected monitor, clear `SelectedRegion`/`HasSelectedRegion`, surface `RecordingStatus` ('Saved region's monitor is no longer connected - please select a new region'), and return null. This forces the user to reselect on the current display topology.
+- **What didn't work**: Silently falling back to `allMonitors.FirstOrDefault()` - the region's monitor-local DIPs got applied to the wrong (primary) monitor, producing a clamped/off-screen capture and a misplaced red border.
+## Region Picker - "blank on open / silent on cancel" confusion
 
 **Approaches tried:**
 
-1. **Pre-render initial region in `RegionSelectorOverlay.OnLoaded`** � Worked. Added `ShowAsync(CaptureRegion? initialRegion)` overload; `OnLoaded` now seeds `_selX/_selY/_selW/_selH` and `_hasSelection = true` from the caller-supplied region (or persisted last region as fallback), then calls `UpdateOverlay()`. User now opens onto their existing rectangle with handles instead of a blank dark canvas. ?
-2. **Track cancel vs confirm via `WasCancelled` property on the overlay** � Worked. `CancelSelection` sets `WasCancelled = true` before resolving the TCS with null. `RecordingPage.LaunchRegionPickerAsync` reads it after `ShowAsync` returns null to distinguish "user pressed Escape ? no-op" from "first-time open with no prior selection". On Escape with an existing selection, page shows an InfoBar: *"Region selection cancelled � kept previous region."* � eliminates the pixel-identical confusion. ?
+1. **Pre-render initial region in `RegionSelectorOverlay.OnLoaded`** - Worked. Added `ShowAsync(CaptureRegion? initialRegion)` overload; `OnLoaded` now seeds `_selX/_selY/_selW/_selH` and `_hasSelection = true` from the caller-supplied region (or persisted last region as fallback), then calls `UpdateOverlay()`. User now opens onto their existing rectangle with handles instead of a blank dark canvas. ?
+2. **Track cancel vs confirm via `WasCancelled` property on the overlay** - Worked. `CancelSelection` sets `WasCancelled = true` before resolving the TCS with null. `RecordingPage.LaunchRegionPickerAsync` reads it after `ShowAsync` returns null to distinguish "user pressed Escape ? no-op" from "first-time open with no prior selection". On Escape with an existing selection, page shows an InfoBar: *"Region selection cancelled - kept previous region."* - eliminates the pixel-identical confusion. ?
 
 **What worked:** Both fixes together. Pre-render eliminates the blank-screen surprise; InfoBar makes Escape's no-op explicit.
 
 **What didn't work / not chosen:**
 
-- Returning a richer result type (e.g. `RegionPickerResult { Region, WasCancelled }`) � would be cleaner but required more surface area changes; `WasCancelled` as a property on the overlay (already a stateful UserControl) was the smaller diff.
+- Returning a richer result type (e.g. `RegionPickerResult { Region, WasCancelled }`) - would be cleaner but required more surface area changes; `WasCancelled` as a property on the overlay (already a stateful UserControl) was the smaller diff.
 
 ---
 
@@ -1286,18 +1286,18 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 
 **Approaches tried:**
 
-1. **Per-page `RecordingViewModel` (original)** � Didn't work. `RecordingPage` declared `public RecordingViewModel ViewModel { get; } = new();` so every navigation back to the page constructed a fresh VM, losing `CaptureMode`, `SelectedWindow`, `SelectedRegion`, `HasSelectedRegion`, and audio toggles. Region survived only because it was persisted to `ApplicationData.LocalSettings` via `RegionMemory`.
-2. **Shared singleton `RecordingViewModel.Shared`** � Worked. Page now uses `ViewModel { get; } = RecordingViewModel.Shared;` so all selection state survives Editor ? Record navigation. ?
-3. **Per-navigation event subscription** � Required companion fix. Constructor-based `ViewModel.PropertyChanged += �` on a shared VM would leak page references (the VM holds the lambda which captures `this`). Moved subscription to `OnNavigatedTo` and added matching tear-down in `OnNavigatedFrom` so prior page instances can be GC'd. ?
+1. **Per-page `RecordingViewModel` (original)** - Didn't work. `RecordingPage` declared `public RecordingViewModel ViewModel { get; } = new();` so every navigation back to the page constructed a fresh VM, losing `CaptureMode`, `SelectedWindow`, `SelectedRegion`, `HasSelectedRegion`, and audio toggles. Region survived only because it was persisted to `ApplicationData.LocalSettings` via `RegionMemory`.
+2. **Shared singleton `RecordingViewModel.Shared`** - Worked. Page now uses `ViewModel { get; } = RecordingViewModel.Shared;` so all selection state survives Editor ? Record navigation. ?
+3. **Per-navigation event subscription** - Required companion fix. Constructor-based `ViewModel.PropertyChanged += -` on a shared VM would leak page references (the VM holds the lambda which captures `this`). Moved subscription to `OnNavigatedTo` and added matching tear-down in `OnNavigatedFrom` so prior page instances can be GC'd. ?
 
 **What worked:** Shared VM + navigation-scoped event lifecycle.
 
 **What didn't work / not chosen:**
 
-- Re-hydrating only `SelectedRegion` from `LoadLastRegion()` in `UpdateRegionInfoDisplay` (already existed) � insufficient because `CaptureMode` and `SelectedWindow` were not persisted, and on fresh-install `LocalSettings` is empty.
-- `NavigationCacheMode=Required` on the page � would also work but caches the entire visual tree; singleton VM is a smaller, more explicit contract.
-- **What worked**: When the saved `CaptureRegion.MonitorId` no longer matches any connected monitor, clear `SelectedRegion`/`HasSelectedRegion`, surface `RecordingStatus` ('Saved region's monitor is no longer connected � please select a new region'), and return null. This forces the user to reselect on the current display topology.
-- **What didn't work**: Silently falling back to `allMonitors.FirstOrDefault()` � the region's monitor-local DIPs got applied to the wrong (primary) monitor, producing a clamped/off-screen capture and a misplaced red border.
+- Re-hydrating only `SelectedRegion` from `LoadLastRegion()` in `UpdateRegionInfoDisplay` (already existed) - insufficient because `CaptureMode` and `SelectedWindow` were not persisted, and on fresh-install `LocalSettings` is empty.
+- `NavigationCacheMode=Required` on the page - would also work but caches the entire visual tree; singleton VM is a smaller, more explicit contract.
+- **What worked**: When the saved `CaptureRegion.MonitorId` no longer matches any connected monitor, clear `SelectedRegion`/`HasSelectedRegion`, surface `RecordingStatus` ('Saved region's monitor is no longer connected - please select a new region'), and return null. This forces the user to reselect on the current display topology.
+- **What didn't work**: Silently falling back to `allMonitors.FirstOrDefault()` - the region's monitor-local DIPs got applied to the wrong (primary) monitor, producing a clamped/off-screen capture and a misplaced red border.
 
 ---
 
@@ -1309,11 +1309,11 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 
 **Approaches tried:**
 
-1. **Timestamp-based trim with `NotifyStopRequested()`** � Worked. Added a `NotifyStopRequested()` method to `MouseHookRecorder` that records the current `Stopwatch.GetTimestamp()` and sets `_paused = true` to stop collecting new events. A static `TrimStopClick()` method on `MouseRecordingData` finds the last left-button-down click within 200ms before the stop-requested timestamp and removes it, its corresponding up event, and button samples. Move/scroll samples are preserved. ?
+1. **Timestamp-based trim with `NotifyStopRequested()`** - Worked. Added a `NotifyStopRequested()` method to `MouseHookRecorder` that records the current `Stopwatch.GetTimestamp()` and sets `_paused = true` to stop collecting new events. A static `TrimStopClick()` method on `MouseRecordingData` finds the last left-button-down click within 200ms before the stop-requested timestamp and removes it, its corresponding up event, and button samples. Move/scroll samples are preserved. ?
 
 **What worked:** Signaling the mouse recorder from the overlay's `Stop_Click` and `OnOverlayClosing` handlers (earliest possible point in the stop flow), then trimming the stop-trigger click in `GetRecordedData()`. The 200ms threshold is generous enough for UI dispatch delay (~3-10ms typical) while avoiding false positives.
 
-**What didn't work:** N/A � first approach worked.
+**What didn't work:** N/A - first approach worked.
 
 **Build notes:** The `dotnet build` CLI fails on Musio.Core/App due to missing WinAppSDK packaging tasks (`ExpandPriContent`). Use MSBuild from VS (`"C:\Program Files\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin\amd64\MSBuild.exe"`) for building. Tests require `DOTNET_ROLL_FORWARD=LatestMajor` since .NET 9 runtime is not installed (only 8 and 10).
 
@@ -1335,27 +1335,27 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 
 ---
 
-## Region Selector Overlay & Recording Page � PR Review Fixes
+## Region Selector Overlay & Recording Page - PR Review Fixes
 
 **Approaches tried:**
 
-1. **TryApplyPresetRegion coordinate space bug** � Was assigning CaptureRegion.X/Y/Width/Height (monitor-local DIPs) directly into overlay selection coords (virtual-desktop overlay DIPs). On multi-monitor / mixed-DPI this seeded the wrong place/size. Fixed by converting monitor-local DIPs ? physical pixels (using saved monitor's origin + GetMonitorDpiScale) ? overlay DIPs (subtract virtual-desktop origin from SM_X/YVIRTUALSCREEN, divide by _screenshotWidth/ActualWidth). ?
-2. **UpdateOverlay degenerate-selection state leak** � When sw/sh clamped to <=0, the blank overlay rendered but _hasSelection and ButtonPanel.Visibility were left set. Now clears _hasSelection/_sel* and hides ButtonPanel in the degenerate branch. ?
-3. **RecordingPage._infoBarTimer navigation leak** � Timer was created on the page's DispatcherQueue and retained OnInfoBarTimerTick, keeping the page alive after navigation. Now Stop() + detach Tick handler + close InfoBar in OnNavigatedFrom. ?
+1. **TryApplyPresetRegion coordinate space bug** - Was assigning CaptureRegion.X/Y/Width/Height (monitor-local DIPs) directly into overlay selection coords (virtual-desktop overlay DIPs). On multi-monitor / mixed-DPI this seeded the wrong place/size. Fixed by converting monitor-local DIPs ? physical pixels (using saved monitor's origin + GetMonitorDpiScale) ? overlay DIPs (subtract virtual-desktop origin from SM_X/YVIRTUALSCREEN, divide by _screenshotWidth/ActualWidth). ?
+2. **UpdateOverlay degenerate-selection state leak** - When sw/sh clamped to <=0, the blank overlay rendered but _hasSelection and ButtonPanel.Visibility were left set. Now clears _hasSelection/_sel* and hides ButtonPanel in the degenerate branch. ?
+3. **RecordingPage._infoBarTimer navigation leak** - Timer was created on the page's DispatcherQueue and retained OnInfoBarTimerTick, keeping the page alive after navigation. Now Stop() + detach Tick handler + close InfoBar in OnNavigatedFrom. ?
 
 **What worked:** All three above.
 
 
 ---
 
-## Editor � Spacebar Play/Pause Shortcut
+## Editor - Spacebar Play/Pause Shortcut
 
 **Feature/area:** EditorPage keyboard accelerators / Preview playback.
 
 **Approaches tried:**
 
-1. **Page-level `KeyboardAccelerator` with `Key="Space"` invoking `Preview.Play()`/`Preview.Pause()` based on `Preview.IsPlaying`** � Worked. ?
-2. **Skip handler when a text input has focus** � Used `FocusManager.GetFocusedElement(XamlRoot)` and bailed for `TextBox`/`PasswordBox`/`RichEditBox`/`AutoSuggestBox` so typing a space in editable fields isn't hijacked. ?
+1. **Page-level `KeyboardAccelerator` with `Key="Space"` invoking `Preview.Play()`/`Preview.Pause()` based on `Preview.IsPlaying`** - Worked. ?
+2. **Skip handler when a text input has focus** - Used `FocusManager.GetFocusedElement(XamlRoot)` and bailed for `TextBox`/`PasswordBox`/`RichEditBox`/`AutoSuggestBox` so typing a space in editable fields isn't hijacked. ?
 
 **What worked:** XAML accelerator + focus-check guard in the handler.
 
@@ -1363,9 +1363,9 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 
 ---
 
-## Overlapping Zoom Segments � Center Snap Fix
+## Overlapping Zoom Segments - Center Snap Fix
 
-**Feature/area:** AutoZoomEngine � focal-point continuity across overlapping zoom segments
+**Feature/area:** AutoZoomEngine - focal-point continuity across overlapping zoom segments
 
 **Approaches tried:**
 1. Earlier fix used max-zoom-wins for both zoom level and center (cx/cy). Zoom level stayed continuous, but the *center* snapped at the instant B's zoom first exceeded A's, since the winning keyframe's center was used wholesale. Editing a segment moved where this snap occurred, making the visual jump obvious.
@@ -1377,7 +1377,7 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 - Regression test `GetZoomState_OverlappingManualKeyframes_CenterDoesNotSnap` steps through the overlap and asserts per-step center delta stays well under the would-be snap magnitude.
 
 **What didn't work:**
-- Returning the max-zoom segment's center as-is � produces a discontinuous jump at the crossover when overlapping segments have different centers.
+- Returning the max-zoom segment's center as-is - produces a discontinuous jump at the crossover when overlapping segments have different centers.
 
 ---
 
@@ -1387,12 +1387,12 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 
 **Approaches tried:**
 
-1. **Make StyleButton/StyleSeparator visible unconditionally in InitializeStyleControls** � Worked. Previously gated on Window/Region only; now exposed for Monitor too. ✅
-2. **Move the Monitor background-defaults override (Padding=0, CornerRadius=0, ShadowEnabled=false, BorderEnabled=false) from `EditorPage.InitializePreviewAsync` into `ProjectService.SetProject`** � Worked. Defaults apply at project-load time so user edits via the now-visible style menu survive editor re-navigation. ✅
+1. **Make StyleButton/StyleSeparator visible unconditionally in InitializeStyleControls** - Worked. Previously gated on Window/Region only; now exposed for Monitor too. ✅
+2. **Move the Monitor background-defaults override (Padding=0, CornerRadius=0, ShadowEnabled=false, BorderEnabled=false) from `EditorPage.InitializePreviewAsync` into `ProjectService.SetProject`** - Worked. Defaults apply at project-load time so user edits via the now-visible style menu survive editor re-navigation. ✅
 
-**What worked:** Combination � unconditional style-menu visibility + applying Monitor defaults in `ProjectService.SetProject` (instead of every `InitializePreviewAsync`).
+**What worked:** Combination - unconditional style-menu visibility + applying Monitor defaults in `ProjectService.SetProject` (instead of every `InitializePreviewAsync`).
 
-**What didn't work:** Leaving the Monitor override unconditional in `InitializePreviewAsync` � would clobber user edits every time the EditorPage was re-constructed.
+**What didn't work:** Leaving the Monitor override unconditional in `InitializePreviewAsync` - would clobber user edits every time the EditorPage was re-constructed.
 
 ---
 
@@ -1457,11 +1457,11 @@ This file tracks approaches tried, what worked, and what didn't for each feature
 ## Frame style: padding & aspect ratio isolation (round 3)
 
 ### Feature/area
-FrameCompositor + BackgroundCompositor � decoupling padding from output aspect ratio, and unifying letterbox/padding fill so the wallpaper is one continuous container.
+FrameCompositor + BackgroundCompositor - decoupling padding from output aspect ratio, and unifying letterbox/padding fill so the wallpaper is one continuous container.
 
 ### What didn't work
 - Previous model had `BackgroundCompositor.CalculateOutputSize` return `(source + 2*padding, source + 2*padding)`. This made the output canvas grow with padding, so dragging the padding slider visibly changed the canvas aspect ratio.
-- Drawing letterbox/pillarbox bars by calling `FillBackgroundRect` inside the cropped buffer caused the wallpaper to be rendered separately in the letterbox bars vs the outer padding margin � visible "wallpaper repeat" with two independent containers.
+- Drawing letterbox/pillarbox bars by calling `FillBackgroundRect` inside the cropped buffer caused the wallpaper to be rendered separately in the letterbox bars vs the outer padding margin - visible "wallpaper repeat" with two independent containers.
 
 ### What worked
 - `BackgroundCompositor.CalculateOutputSize` is now identity `(w, h)`: padding insets within the canvas, never extends it.
@@ -1470,7 +1470,7 @@ FrameCompositor + BackgroundCompositor � decoupling padding from output aspect
   - `_innerContentWidth/_innerContentHeight` = canvas - 2*padding (the inner content rect, where source is drawn).
   - `_sourceAreaWidth/Height/OffsetX/Y` describe the source placement WITHIN the inner content area. Cover fills inner; Contain preserves source AR inside inner with letterbox/pillarbox.
 - `CropSourceFrame` sizes `_croppedBuffer` to inner dims and clears to transparent; letterbox bars are no longer filled in the buffer.
-- `BackgroundCompositor.CompositeFrame` already draws the chosen background across the entire output canvas (w � h) before drawing the (now possibly transparent) content into the inset rect. Because the cropped buffer has transparent letterbox regions, the outer wallpaper shows through them as one continuous fill � padding margin + letterbox bars = single container.
+- `BackgroundCompositor.CompositeFrame` already draws the chosen background across the entire output canvas (w - h) before drawing the (now possibly transparent) content into the inset rect. Because the cropped buffer has transparent letterbox regions, the outer wallpaper shows through them as one continuous fill - padding margin + letterbox bars = single container.
 - Cursor and click coord math (`(cursor - viewport)*scale + padding + sourceAreaOffset`) is unchanged: scale uses `_sourceAreaWidth/viewport.Width`, offsets are in inner-buffer space, and `+padding` shifts to outer canvas coords (content is drawn at `(padding, padding)` by BgCompositor).
 
 ### Test impact
@@ -1481,7 +1481,7 @@ FrameCompositor + BackgroundCompositor � decoupling padding from output aspect
 ## Frame style: collapse letterbox + padding into one container (round 4)
 
 ### Feature/area
-FrameCompositor + BackgroundCompositor � eliminating the separate "inner content area" / "letterbox bars" concept so there is exactly one background container around the source frame.
+FrameCompositor + BackgroundCompositor - eliminating the separate "inner content area" / "letterbox bars" concept so there is exactly one background container around the source frame.
 
 ### What worked
 - Removed `_innerContentWidth/_innerContentHeight` fields entirely.
@@ -1490,7 +1490,7 @@ FrameCompositor + BackgroundCompositor � eliminating the separate "inner conte
 - `ComputeContentDimensions`: compute canvas (target AR, padding-independent), then a max content box (canvas - 2*userPadding), then fit source into it per FitMode, finally CENTER the source within the canvas (so leftover gap is simply more background).
 - `CropSourceFrame`: buffer is sized exactly to the source-area dims (no internal letterbox padding). Drawing 1:1.
 - `BackgroundCompositor.CompositeFrame` simplified signature: takes srcX/srcY/srcWidth/srcHeight directly (no padding/inner concept). Background fills the entire canvas; shadow / rounded-corner clip / border all use the source rect.
-- Cursor/click/post-composite-zoom coord math: removed the separate `+padding` term � `_sourceAreaOffset*` now already includes total background gap.
+- Cursor/click/post-composite-zoom coord math: removed the separate `+padding` term - `_sourceAreaOffset*` now already includes total background gap.
 
 ### Outcome
 - Shadow and rounded corners wrap the actual visible captured frame, not the larger "inner content" container.
@@ -1599,7 +1599,7 @@ has no shadow/corner even though the preview shows them correctly.
 `ExportFlyout_Opened` short-circuits if `ExportVM.ExportSucceeded` is true.
 The flag is only reset by the explicit "Close" button (`CloseFlyout_Click`).
 Dismissing the flyout by clicking outside leaves the flag set, so the next
-"open" just re-shows the cached `ExportedFilePath` from the previous run �
+"open" just re-shows the cached `ExportedFilePath` from the previous run -
 no fresh `PrepareForExport` is called and no new export runs. The user
 believes they triggered a 2nd export and inspects the 1st (pre-style) file.
 
@@ -1692,7 +1692,7 @@ the success message. Resetting on close is cleaner and matches user intent.
 
 **What worked:** Tracking the last persisted move timestamp and resetting it in `StartRecording()` caps high-frequency move samples without changing the binary serialization format.
 
-**What didn't work:** Full solution MSBuild still fails in pre-existing App errors (`FindMonitorBoundsForOverlayPoint`, `ClampPointToRect`); targeted Core build hits a pre-existing `Buffer` ambiguity in `VideoWriter.cs`.
+**What didn't work:** Earlier validation was blocked by pre-existing App/Core build issues, but those repo-level blockers have since been resolved by adding `FindMonitorBoundsForOverlayPoint` / `ClampPointToRect` and qualifying `Windows.Storage.Streams.Buffer` usage.
 
 ---
 
@@ -1712,7 +1712,7 @@ the success message. Resetting on close is cleaner and matches user intent.
 
 ---
 
-## Crash/Freeze Hardening Pass � High-DPI / High-Res Stability (13 fixes)
+## Crash/Freeze Hardening Pass - High-DPI / High-Res Stability (13 fixes)
 
 **Feature/area:** Capture pipeline, compositor, export, picker overlays, mouse hook.
 
@@ -1720,30 +1720,31 @@ the success message. Resetting on close is cleaner and matches user intent.
 
 **What worked:**
 
-1. **Streaming MP4 finalize** in `VideoWriter.FinalizeAsync` � replaced per-frame `MediaClip` + `MediaComposition.RenderToFileAsync` with a streaming `MediaStreamSource` + `MediaTranscoder` (BGRA8 ? H.264, 20 Mbps, mod-2 dims, CFR). Eliminates 100k+ COM objects on long recordings. Same encoding settings ? identical output quality. `MediaTranscoder.HardwareAccelerationEnabled = false` to avoid AMD H.264 corruption.
-2. **In-flight write drain** � `VideoWriter.StopAcceptingFrames()` + `WaitForQuiescenceAsync()` replace the fixed 500ms sleep in `RecordingSession.StopAsync`.
-3. **Serialized crop+write** � entire `WriteFrame` body now runs under `_writeLock`; shared `_cropTarget` no longer races on free-threaded frame-pool callbacks.
-4. **`TryGetNextFrame()` inside try/catch** � `ObjectDisposedException`/`COMException` during shutdown/device-lost/monitor hot-plug no longer crash the process.
-5. **D3D HRESULT + WARP fallback + `CanvasDevice.DeviceLost`** � `Direct3DDeviceHelper` checks `D3D11CreateDevice` HRESULT and falls back to WARP. `FrameCompositor` / `VideoEncoder` subscribe `DeviceLost` and throw a recoverable exception (no mid-frame recreate).
-6. **Virtual-desktop screenshot guards** � `RegionSelectorOverlay` / `WindowSelectorOverlay` reject `width*height*4 > 1 GB` or `>16384px`, with checked `long` arithmetic and GDI return-value validation. Fall back to solid overlay.
-7. **VRAM preflight** � `FrameCompositor` / `VideoEncoder` estimate BGRA surface bytes; throw a clear `InvalidOperationException` above 1.5 GB. Wraps `CanvasRenderTarget` allocations in OOM/COM try/catch with cache release + context rethrow. Normal =4K exports unaffected.
-8. **`GraphicsCaptureItem.Closed`** � `ScreenCaptureEngine` subscribes/unsubscribes; on close, one-shot guard calls `StopCapture()` so `CaptureStopped` fires.
-9. **`IAsyncDisposable` on `RecordingSession`** � sync `Dispose()` is non-blocking best-effort (no MP4 finalize). `DisposeAsync()` does graceful stop with 30s timeout. Finalize accepts `CancellationToken`.
-10. **Transcode watchdog** � 2-hour timeout via linked CTS around first-pass `VideoEncoder.ExportAsync` `TranscodeAsync` (mirrors mux pattern).
-11. **Mouse move throttle at 250 Hz** � `MouseHookRecorder` skips pure `WM_MOUSEMOVE` samples within 4ms of the last; clicks/scrolls/buttons always preserved. Serialization format unchanged.
-12. **Window picker covers virtual desktop** � `WindowSelectorOverlay` replaces `presenter.Maximize()` with `AppWindow.MoveAndResize` over the full virtual desktop (mirrors region picker).
-13. **Region drag clamped to active monitor (Option A)** � drag rectangle visually sticks at monitor edges of the monitor containing the drag origin; saved region equals what's drawn. No popup/error.
+1. **Streaming MP4 finalize** in `VideoWriter.FinalizeAsync` - replaced per-frame `MediaClip` + `MediaComposition.RenderToFileAsync` with a streaming `MediaStreamSource` + `MediaTranscoder` (BGRA8 -> H.264, 20 Mbps, mod-2 dims, CFR). Eliminates 100k+ COM objects on long recordings. Same encoding settings -> identical output quality. `MediaTranscoder.HardwareAccelerationEnabled = false` to avoid AMD H.264 corruption.
+2. **In-flight write drain** - `VideoWriter.StopAcceptingFrames()` + `WaitForQuiescenceAsync()` replace the fixed 500ms sleep in `RecordingSession.StopAsync`.
+3. **Serialized crop+write** - entire `WriteFrame` body now runs under `_writeLock`; shared `_cropTarget` no longer races on free-threaded frame-pool callbacks.
+4. **`TryGetNextFrame()` inside try/catch** - `ObjectDisposedException`/`COMException` during shutdown/device-lost/monitor hot-plug no longer crash the process.
+5. **D3D HRESULT + WARP fallback + `CanvasDevice.DeviceLost`** - `Direct3DDeviceHelper` checks `D3D11CreateDevice` HRESULT and falls back to WARP. `FrameCompositor` / `VideoEncoder` subscribe `DeviceLost` and throw a recoverable exception (no mid-frame recreate).
+6. **Virtual-desktop screenshot guards** - `RegionSelectorOverlay` / `WindowSelectorOverlay` reject `width*height*4 > 1 GB` or `>16384px`, with checked `long` arithmetic and GDI return-value validation. Fall back to solid overlay.
+7. **VRAM preflight** - `FrameCompositor` / `VideoEncoder` estimate BGRA surface bytes; throw a clear `InvalidOperationException` above 1.5 GB. Wraps `CanvasRenderTarget` allocations in OOM/COM try/catch with cache release + context rethrow. Normal <=4K exports unaffected.
+8. **`GraphicsCaptureItem.Closed`** - `ScreenCaptureEngine` subscribes/unsubscribes; on close, one-shot guard calls `StopCapture()` so `CaptureStopped` fires.
+9. **`IAsyncDisposable` on `RecordingSession`** - sync `Dispose()` is non-blocking best-effort (no MP4 finalize). `DisposeAsync()` does graceful stop with 30s timeout. Finalize accepts `CancellationToken`.
+10. **Transcode watchdog** - 2-hour timeout around first-pass `VideoEncoder.ExportAsync` `TranscodeAsync` (mirrors mux pattern; uses `ct.Register` directly).
+11. **Mouse move throttle at 250 Hz** - `MouseHookRecorder` skips pure `WM_MOUSEMOVE` samples within 4ms of the last; clicks/scrolls/buttons always preserved. Serialization format unchanged.
+12. **Window picker covers virtual desktop** - `WindowSelectorOverlay` replaces `presenter.Maximize()` with `AppWindow.MoveAndResize` over the full virtual desktop (mirrors region picker).
+13. **Region drag clamped to active monitor (Option A)** - drag rectangle visually sticks at monitor edges of the monitor containing the drag origin; saved region equals what is drawn. No popup/error.
 
 **Validation:**
-- All three projects build clean via VS Enterprise MSBuild (`vswhere -latest -find 'MSBuild\**\Bin\MSBuild.exe'` ? `Program Files\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin\MSBuild.exe`) with `/p:Platform=x64 /p:Configuration=Debug /restore`.
-- MSTest run could not execute in this environment (host has .NET 8 and .NET 10 but not .NET 9 runtime in x64). Build-clean is the strongest available validation; behavior verification needs end-to-end manual recording/export on a target device.
+- All three projects build clean via VS Enterprise MSBuild (`vswhere -latest -find 'MSBuild\**\Bin\MSBuild.exe'` -> `Program Files\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin\MSBuild.exe`) with `/p:Platform=x64 /p:Configuration=Debug /restore`.
+- All 286 MSTest tests pass. The host has .NET 8 and .NET 10 SDKs/runtimes but no .NET 9 runtime, so tests were executed with `DOTNET_ROLL_FORWARD=Major` to roll forward to the .NET 10 runtime.
 
 **What didn't work / things to remember:**
 - `dotnet build` still fails for this repo (PriGen MSB4062). Use VS MSBuild.
 - `Get-Command MSBuild.exe` returns nothing; use `vswhere -latest -find` to locate it.
-- Don't rely on `dotnet test` in this environment without a .NET 9 runtime installed alongside the SDK.
-- For #1, the cleanest BGRA?H.264 path is `BitmapDecoder` ? `SoftwareBitmap` (BGRA8) ? `MediaStreamSample.CreateFromBuffer`. Avoid `MediaComposition` for any per-frame encoding.
-- For #5, do NOT recreate the device mid-frame on `DeviceLost` � surface a recoverable exception and let outer code restart cleanly.
+- Without a .NET 9 runtime installed, `dotnet test` aborts the test host; set `DOTNET_ROLL_FORWARD=Major` to run against the installed .NET 10 runtime.
+- For #1, the cleanest BGRA->H.264 path is `BitmapDecoder` -> `SoftwareBitmap` (BGRA8) -> `MediaStreamSample.CreateFromBuffer`. Avoid `MediaComposition` for any per-frame encoding.
+- For #5, do NOT recreate the device mid-frame on `DeviceLost` - surface a recoverable exception and let outer code restart cleanly.
+
 ## Window selection highlight rect overstating bounds (2026-05-24)
 
 **Feature/area**: WindowSelectorOverlay / RegionSelector
@@ -1760,4 +1761,4 @@ the success message. Resetting on close is cleaner and matches user intent.
 
 **Problem**: Precisely-selected region captures included an extra 1px on the left/top edge.
 
-**Approach tried (reverted)**: Hypothesized the cause was DIP↔physical-pixel round-trip rounding at fractional DPI. Extended `CaptureRegion` with optional `PixelX/Y/Width/Height`, threaded a `CropIsPhysicalPixels` flag through `CaptureTarget`, and skipped the DPI multiply in `RecordingSession`. **User confirmed this did not fix the 1px offset**, so the changes were reverted. The actual cause lies elsewhere (possibly in selection overlay rendering, stroke alignment, screenshot/Image stretch mapping, or the captured frame origin itself). Investigate before re-attempting.
+**Approach tried (reverted)**: Hypothesized the cause was DIP<->physical-pixel round-trip rounding at fractional DPI. Extended `CaptureRegion` with optional `PixelX/Y/Width/Height`, threaded a `CropIsPhysicalPixels` flag through `CaptureTarget`, and skipped the DPI multiply in `RecordingSession`. **User confirmed this did not fix the 1px offset**, so the changes were reverted. The actual cause lies elsewhere (possibly in selection overlay rendering, stroke alignment, screenshot/Image stretch mapping, or the captured frame origin itself). Investigate before re-attempting.

--- a/learnings.md
+++ b/learnings.md
@@ -1680,3 +1680,67 @@ the success message. Resetting on close is cleaner and matches user intent.
 **What worked:** `DesktopAcrylicBackdrop` (Microsoft.UI.Xaml.Media) as the window backdrop with default DWM corner rounding; removed the GDI region clip that decoupled the body from the shadow.
 
 **What didn't work:** `SetWindowRgn` for a full pill shape - it clips only the window contents, not the DWM shadow, so the shadow stayed rectangular.
+
+---
+
+## Mouse Move Sample Throttling at 250Hz
+
+**Feature/area:** MouseHookRecorder move-event recording.
+
+**Approaches tried:**
+1. **Stopwatch-based pure `WM_MOUSEMOVE` gate in `HookCallback()`** â€” Worked. Added a 4ms minimum interval between persisted move samples while leaving button and scroll samples unthrottled.
+
+**What worked:** Tracking the last persisted move timestamp and resetting it in `StartRecording()` caps high-frequency move samples without changing the binary serialization format.
+
+**What didn't work:** Full solution MSBuild still fails in pre-existing App errors (`FindMonitorBoundsForOverlayPoint`, `ClampPointToRect`); targeted Core build hits a pre-existing `Buffer` ambiguity in `VideoWriter.cs`.
+
+---
+
+## Crash/freeze hardening - D3D, Win2D, VRAM, export watchdog
+
+**Feature/area:** `Direct3DDeviceHelper`, `FrameCompositor`, `VideoEncoder`
+
+**Approaches tried:**
+- Checked `D3D11CreateDevice` HRESULT and retried hardware failures with WARP (`D3D_DRIVER_TYPE_WARP = 5`).
+- Subscribed shared `CanvasDevice.DeviceLost` handlers and converted later use into recoverable exceptions instead of recreating devices mid-frame.
+- Added BGRA render-target memory preflights plus OOM/COM allocation wrapping for full-frame `CanvasRenderTarget` allocations.
+- Wrapped first-pass `TranscodeAsync` with a 2-hour watchdog using cancellation, mirroring the audio mux timeout pattern.
+
+**What worked:** Fail-fast validation and recoverable exception paths keep exports from crashing/freezing while preserving quality and normal <=4K behavior.
+
+**What didn't work:** `MSBuild.exe` was not available via `Get-Command MSBuild.exe`, so validation was limited to re-reading modified files and `git diff --check`; do not use `dotnet build` for this repo.
+
+---
+
+## Crash/Freeze Hardening Pass — High-DPI / High-Res Stability (13 fixes)
+
+**Feature/area:** Capture pipeline, compositor, export, picker overlays, mouse hook.
+
+**Context:** Reports of freezes/crashes on high-DPI and high-resolution devices. Rubber-duck reviewed the codebase; 13 hardening items implemented in parallel by 5 sub-agents across non-overlapping file groups. No functionality or export-quality change.
+
+**What worked:**
+
+1. **Streaming MP4 finalize** in `VideoWriter.FinalizeAsync` — replaced per-frame `MediaClip` + `MediaComposition.RenderToFileAsync` with a streaming `MediaStreamSource` + `MediaTranscoder` (BGRA8 ? H.264, 20 Mbps, mod-2 dims, CFR). Eliminates 100k+ COM objects on long recordings. Same encoding settings ? identical output quality. `MediaTranscoder.HardwareAccelerationEnabled = false` to avoid AMD H.264 corruption.
+2. **In-flight write drain** — `VideoWriter.StopAcceptingFrames()` + `WaitForQuiescenceAsync()` replace the fixed 500ms sleep in `RecordingSession.StopAsync`.
+3. **Serialized crop+write** — entire `WriteFrame` body now runs under `_writeLock`; shared `_cropTarget` no longer races on free-threaded frame-pool callbacks.
+4. **`TryGetNextFrame()` inside try/catch** — `ObjectDisposedException`/`COMException` during shutdown/device-lost/monitor hot-plug no longer crash the process.
+5. **D3D HRESULT + WARP fallback + `CanvasDevice.DeviceLost`** — `Direct3DDeviceHelper` checks `D3D11CreateDevice` HRESULT and falls back to WARP. `FrameCompositor` / `VideoEncoder` subscribe `DeviceLost` and throw a recoverable exception (no mid-frame recreate).
+6. **Virtual-desktop screenshot guards** — `RegionSelectorOverlay` / `WindowSelectorOverlay` reject `width*height*4 > 1 GB` or `>16384px`, with checked `long` arithmetic and GDI return-value validation. Fall back to solid overlay.
+7. **VRAM preflight** — `FrameCompositor` / `VideoEncoder` estimate BGRA surface bytes; throw a clear `InvalidOperationException` above 1.5 GB. Wraps `CanvasRenderTarget` allocations in OOM/COM try/catch with cache release + context rethrow. Normal =4K exports unaffected.
+8. **`GraphicsCaptureItem.Closed`** — `ScreenCaptureEngine` subscribes/unsubscribes; on close, one-shot guard calls `StopCapture()` so `CaptureStopped` fires.
+9. **`IAsyncDisposable` on `RecordingSession`** — sync `Dispose()` is non-blocking best-effort (no MP4 finalize). `DisposeAsync()` does graceful stop with 30s timeout. Finalize accepts `CancellationToken`.
+10. **Transcode watchdog** — 2-hour timeout via linked CTS around first-pass `VideoEncoder.ExportAsync` `TranscodeAsync` (mirrors mux pattern).
+11. **Mouse move throttle at 250 Hz** — `MouseHookRecorder` skips pure `WM_MOUSEMOVE` samples within 4ms of the last; clicks/scrolls/buttons always preserved. Serialization format unchanged.
+12. **Window picker covers virtual desktop** — `WindowSelectorOverlay` replaces `presenter.Maximize()` with `AppWindow.MoveAndResize` over the full virtual desktop (mirrors region picker).
+13. **Region drag clamped to active monitor (Option A)** — drag rectangle visually sticks at monitor edges of the monitor containing the drag origin; saved region equals what's drawn. No popup/error.
+
+**Validation:**
+- All three projects build clean via VS Enterprise MSBuild (`vswhere -latest -find 'MSBuild\**\Bin\MSBuild.exe'` ? `Program Files\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin\MSBuild.exe`) with `/p:Platform=x64 /p:Configuration=Debug /restore`.
+- MSTest run could not execute in this environment (host has .NET 8 and .NET 10 but not .NET 9 runtime in x64). Build-clean is the strongest available validation; behavior verification needs end-to-end manual recording/export on a target device.
+
+**What didn't work / things to remember:**
+- `dotnet build` still fails for this repo (PriGen MSB4062). Use VS MSBuild.
+- `Get-Command MSBuild.exe` returns nothing; use `vswhere -latest -find` to locate it.
+- Don't rely on `dotnet test` in this environment without a .NET 9 runtime installed alongside the SDK.
+- For #1, the cleanest BGRA?H.264 path is `BitmapDecoder` ? `SoftwareBitmap` (BGRA8) ? `MediaStreamSample.CreateFromBuffer`. Avoid `MediaComposition` for any per-frame encoding.
+- For #5, do NOT recreate the device mid-frame on `DeviceLost` — surface a recoverable exception and let outer code restart cleanly.

--- a/src/Musio.App/Controls/RegionSelectorOverlay.xaml.cs
+++ b/src/Musio.App/Controls/RegionSelectorOverlay.xaml.cs
@@ -28,6 +28,7 @@ public sealed partial class RegionSelectorOverlay : UserControl
     private bool _isResizing;
     private string _resizeHandle = "";
     private Point _resizeStart;
+    private Rect? _activeDragBounds;
 
     private double _selX, _selY, _selW, _selH;
     private bool _hasSelection;
@@ -63,6 +64,7 @@ public sealed partial class RegionSelectorOverlay : UserControl
     private const double MinSelectionSize = 10;
     private const int SnapRadius = 15;
     private const float SnapMinContrast = 12.0f;
+    private const long MaxScreenshotBytes = 1_073_741_824L; // 1 GB
 
     public event EventHandler<CaptureRegion>? RegionSelected;
     public event EventHandler? SelectionCancelled;
@@ -290,25 +292,56 @@ public sealed partial class RegionSelectorOverlay : UserControl
         IntPtr hdcMem = IntPtr.Zero;
         IntPtr hBitmap = IntPtr.Zero;
         IntPtr oldObj = IntPtr.Zero;
+        int width = 0;
+        int height = 0;
 
         try
         {
             int left = GetSystemMetrics(SM_XVIRTUALSCREEN);
             int top = GetSystemMetrics(SM_YVIRTUALSCREEN);
-            int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
-            int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+            width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+            height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 
             if (width <= 0 || height <= 0)
                 return (null, null, 0, 0);
+            if (width > 16384 || height > 16384)
+                return (null, null, width, height);
+
+            long byteCount;
+            try
+            {
+                byteCount = checked((long)width * height * 4L);
+            }
+            catch (OverflowException)
+            {
+                return (null, null, width, height);
+            }
+
+            if (byteCount > MaxScreenshotBytes)
+                return (null, null, width, height);
 
             hdcScreen = GetDC(IntPtr.Zero);
+            if (hdcScreen == IntPtr.Zero)
+                return (null, null, width, height);
+
             hdcMem = CreateCompatibleDC(hdcScreen);
+            if (hdcMem == IntPtr.Zero)
+                return (null, null, width, height);
+
             hBitmap = CreateCompatibleBitmap(hdcScreen, width, height);
+            if (hBitmap == IntPtr.Zero)
+                return (null, null, width, height);
+
             oldObj = SelectObject(hdcMem, hBitmap);
+            if (oldObj == IntPtr.Zero || oldObj == new IntPtr(-1))
+                return (null, null, width, height);
 
-            BitBlt(hdcMem, 0, 0, width, height, hdcScreen, left, top, SRCCOPY);
+            if (!BitBlt(hdcMem, 0, 0, width, height, hdcScreen, left, top, SRCCOPY))
+                return (null, null, width, height);
 
-            SelectObject(hdcMem, oldObj);
+            IntPtr restoredObj = SelectObject(hdcMem, oldObj);
+            if (restoredObj == IntPtr.Zero || restoredObj == new IntPtr(-1))
+                return (null, null, width, height);
             oldObj = IntPtr.Zero;
 
             // Read pixel data from the HBITMAP
@@ -322,8 +355,10 @@ public sealed partial class RegionSelectorOverlay : UserControl
                 biCompression = 0, // BI_RGB
             };
 
-            var pixelData = new byte[width * height * 4];
-            GetDIBits(hdcMem, hBitmap, 0, (uint)height, pixelData, ref bmi, 0);
+            var pixelData = new byte[(int)byteCount];
+            int scanLines = GetDIBits(hdcMem, hBitmap, 0, (uint)height, pixelData, ref bmi, 0);
+            if (scanLines != height)
+                return (null, null, width, height);
 
             // Convert BGRA pixel data to SoftwareBitmap
             using var softwareBitmap = new SoftwareBitmap(BitmapPixelFormat.Bgra8, width, height, BitmapAlphaMode.Premultiplied);
@@ -336,7 +371,7 @@ public sealed partial class RegionSelectorOverlay : UserControl
         }
         catch
         {
-            return (null, null, 0, 0);
+            return width > 0 && height > 0 ? (null, null, width, height) : (null, null, 0, 0);
         }
         finally
         {
@@ -514,6 +549,7 @@ public sealed partial class RegionSelectorOverlay : UserControl
         // Start new selection
         _isDragging = true;
         _dragStart = pos;
+        _activeDragBounds = FindMonitorBoundsForOverlayPoint(pos);
         _selX = pos.X;
         _selY = pos.Y;
         _selW = 0;
@@ -530,6 +566,9 @@ public sealed partial class RegionSelectorOverlay : UserControl
 
         if (_isDragging)
         {
+            if (_activeDragBounds is Rect bounds)
+                pos = ClampPointToRect(pos, bounds);
+
             _selX = Math.Min(_dragStart.X, pos.X);
             _selY = Math.Min(_dragStart.Y, pos.Y);
             _selW = Math.Abs(pos.X - _dragStart.X);
@@ -580,6 +619,56 @@ public sealed partial class RegionSelectorOverlay : UserControl
         _            => InputSystemCursorShape.Cross,
     };
 
+    private Rect? FindMonitorBoundsForOverlayPoint(Point point)
+    {
+        double canvasW = ActualWidth;
+        double canvasH = ActualHeight;
+        int vdWidth = _screenshotWidth > 0 ? _screenshotWidth : GetSystemMetrics(SM_CXVIRTUALSCREEN);
+        int vdHeight = _screenshotHeight > 0 ? _screenshotHeight : GetSystemMetrics(SM_CYVIRTUALSCREEN);
+        if (canvasW <= 0 || canvasH <= 0 || vdWidth <= 0 || vdHeight <= 0)
+            return null;
+
+        int vdLeft = GetSystemMetrics(SM_XVIRTUALSCREEN);
+        int vdTop = GetSystemMetrics(SM_YVIRTUALSCREEN);
+        double scaleX = canvasW / vdWidth;
+        double scaleY = canvasH / vdHeight;
+
+        foreach (var monitor in _regionSelector.GetMonitors())
+        {
+            var bounds = new Rect(
+                (monitor.X - vdLeft) * scaleX,
+                (monitor.Y - vdTop) * scaleY,
+                monitor.Width * scaleX,
+                monitor.Height * scaleY);
+
+            if (bounds.Width <= 0 || bounds.Height <= 0)
+                continue;
+
+            if (point.X >= bounds.X && point.X <= bounds.X + bounds.Width
+                && point.Y >= bounds.Y && point.Y <= bounds.Y + bounds.Height)
+                return bounds;
+        }
+
+        return null;
+    }
+
+    private static Point ClampPointToRect(Point point, Rect bounds) => new(
+        Math.Clamp(point.X, bounds.X, bounds.X + bounds.Width),
+        Math.Clamp(point.Y, bounds.Y, bounds.Y + bounds.Height));
+
+    private void ClampSelectionToRect(Rect bounds)
+    {
+        double left = Math.Clamp(_selX, bounds.X, bounds.X + bounds.Width);
+        double top = Math.Clamp(_selY, bounds.Y, bounds.Y + bounds.Height);
+        double right = Math.Clamp(_selX + _selW, bounds.X, bounds.X + bounds.Width);
+        double bottom = Math.Clamp(_selY + _selH, bounds.Y, bounds.Y + bounds.Height);
+
+        _selX = Math.Min(left, right);
+        _selY = Math.Min(top, bottom);
+        _selW = Math.Abs(right - left);
+        _selH = Math.Abs(bottom - top);
+    }
+
     private void Grid_PointerReleased(object sender, PointerRoutedEventArgs e)
     {
         bool shiftHeld = IsShiftHeld();
@@ -587,12 +676,16 @@ public sealed partial class RegionSelectorOverlay : UserControl
         if (_isDragging)
         {
             _isDragging = false;
+            var activeDragBounds = _activeDragBounds;
+            _activeDragBounds = null;
             RootGrid.ReleasePointerCapture(e.Pointer);
 
             if (_selW > MinSelectionSize && _selH > MinSelectionSize)
             {
                 if (!shiftHeld)
                     SnapSelectionEdges(snapLeft: true, snapTop: true, snapRight: true, snapBottom: true);
+                if (activeDragBounds is Rect bounds)
+                    ClampSelectionToRect(bounds);
                 ButtonPanel.Visibility = Visibility.Visible;
             }
             else
@@ -856,8 +949,16 @@ public sealed partial class RegionSelectorOverlay : UserControl
             return;
 
         // Overlay DIPs → virtual desktop physical pixels (screen-absolute).
-        double scaleX = ActualWidth > 0 ? _screenshotWidth / ActualWidth : 1.0;
-        double scaleY = ActualHeight > 0 ? _screenshotHeight / ActualHeight : 1.0;
+        int vdWidth = _screenshotWidth > 0 ? _screenshotWidth : GetSystemMetrics(SM_CXVIRTUALSCREEN);
+        int vdHeight = _screenshotHeight > 0 ? _screenshotHeight : GetSystemMetrics(SM_CYVIRTUALSCREEN);
+        if (vdWidth <= 0 || vdHeight <= 0)
+        {
+            CancelSelection();
+            return;
+        }
+
+        double scaleX = ActualWidth > 0 ? vdWidth / ActualWidth : 1.0;
+        double scaleY = ActualHeight > 0 ? vdHeight / ActualHeight : 1.0;
         int vdLeft = GetSystemMetrics(SM_XVIRTUALSCREEN);
         int vdTop = GetSystemMetrics(SM_YVIRTUALSCREEN);
 

--- a/src/Musio.App/Controls/WindowSelectorOverlay.xaml.cs
+++ b/src/Musio.App/Controls/WindowSelectorOverlay.xaml.cs
@@ -23,6 +23,8 @@ public sealed partial class WindowSelectorOverlay : UserControl
     private List<WindowInfo> _windows = new();
     private WindowInfo? _hoveredWindow;
 
+    private const long MaxScreenshotBytes = 1_073_741_824L; // 1 GB
+
     // Virtual desktop bounds (physical pixels)
     private int _vdLeft, _vdTop, _vdWidth, _vdHeight;
 
@@ -91,7 +93,15 @@ public sealed partial class WindowSelectorOverlay : UserControl
             {
                 presenter.SetBorderAndTitleBar(false, false);
                 presenter.IsAlwaysOnTop = true;
-                presenter.Maximize();
+                presenter.IsResizable = false;
+                presenter.IsMaximizable = false;
+                presenter.IsMinimizable = false;
+            }
+
+            if (_vdWidth > 0 && _vdHeight > 0)
+            {
+                _hostWindow.AppWindow.MoveAndResize(new Windows.Graphics.RectInt32(
+                    _vdLeft, _vdTop, _vdWidth, _vdHeight));
             }
 
             if (screenshotSource is not null)
@@ -402,17 +412,44 @@ public sealed partial class WindowSelectorOverlay : UserControl
             int width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
             int height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 
-            if (width <= 0 || height <= 0)
+            if (width <= 0 || height <= 0 || width > 16384 || height > 16384)
+                return null;
+
+            long byteCount;
+            try
+            {
+                byteCount = checked((long)width * height * 4L);
+            }
+            catch (OverflowException)
+            {
+                return null;
+            }
+
+            if (byteCount > MaxScreenshotBytes)
                 return null;
 
             hdcScreen = GetDC(IntPtr.Zero);
+            if (hdcScreen == IntPtr.Zero)
+                return null;
+
             hdcMem = CreateCompatibleDC(hdcScreen);
+            if (hdcMem == IntPtr.Zero)
+                return null;
+
             hBitmap = CreateCompatibleBitmap(hdcScreen, width, height);
+            if (hBitmap == IntPtr.Zero)
+                return null;
+
             oldObj = SelectObject(hdcMem, hBitmap);
+            if (oldObj == IntPtr.Zero || oldObj == new IntPtr(-1))
+                return null;
 
-            BitBlt(hdcMem, 0, 0, width, height, hdcScreen, left, top, SRCCOPY);
+            if (!BitBlt(hdcMem, 0, 0, width, height, hdcScreen, left, top, SRCCOPY))
+                return null;
 
-            SelectObject(hdcMem, oldObj);
+            IntPtr restoredObj = SelectObject(hdcMem, oldObj);
+            if (restoredObj == IntPtr.Zero || restoredObj == new IntPtr(-1))
+                return null;
             oldObj = IntPtr.Zero;
 
             var bmi = new BITMAPINFO
@@ -425,8 +462,10 @@ public sealed partial class WindowSelectorOverlay : UserControl
                 biCompression = 0,
             };
 
-            var pixelData = new byte[width * height * 4];
-            GetDIBits(hdcMem, hBitmap, 0, (uint)height, pixelData, ref bmi, 0);
+            var pixelData = new byte[(int)byteCount];
+            int scanLines = GetDIBits(hdcMem, hBitmap, 0, (uint)height, pixelData, ref bmi, 0);
+            if (scanLines != height)
+                return null;
 
             using var softwareBitmap = new SoftwareBitmap(
                 BitmapPixelFormat.Bgra8, width, height, BitmapAlphaMode.Premultiplied);

--- a/src/Musio.Core/Capture/Direct3DDeviceHelper.cs
+++ b/src/Musio.Core/Capture/Direct3DDeviceHelper.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using Windows.Graphics.DirectX.Direct3D11;
 using WinRT;
@@ -11,17 +13,26 @@ public static class Direct3DDeviceHelper
 {
     public static IDirect3DDevice CreateDevice()
     {
-        D3D11CreateDevice(
-            IntPtr.Zero,
-            D3D_DRIVER_TYPE.D3D_DRIVER_TYPE_HARDWARE,
-            IntPtr.Zero,
-            D3D11_CREATE_DEVICE_FLAG.D3D11_CREATE_DEVICE_BGRA_SUPPORT,
-            null,
-            0,
-            D3D11_SDK_VERSION,
-            out var d3dDevice,
-            out _,
-            out _);
+        object d3dDevice;
+
+        try
+        {
+            d3dDevice = CreateD3D11Device(D3D_DRIVER_TYPE.D3D_DRIVER_TYPE_HARDWARE);
+        }
+        catch (Exception hardwareException)
+        {
+            Debug.WriteLine($"[Direct3DDeviceHelper] Hardware D3D11 device creation failed; falling back to WARP: {hardwareException.Message}");
+
+            try
+            {
+                d3dDevice = CreateD3D11Device(D3D_DRIVER_TYPE.D3D_DRIVER_TYPE_WARP);
+            }
+            catch
+            {
+                ExceptionDispatchInfo.Capture(hardwareException).Throw();
+                throw;
+            }
+        }
 
         // The D3D11 device implements IDXGIDevice; get its IUnknown for the DXGI interop call
         var dxgiDevicePtr = Marshal.GetIUnknownForObject(d3dDevice);
@@ -39,6 +50,23 @@ public static class Direct3DDeviceHelper
         }
     }
 
+    private static object CreateD3D11Device(D3D_DRIVER_TYPE driverType)
+    {
+        var hr = D3D11CreateDevice(
+            IntPtr.Zero,
+            driverType,
+            IntPtr.Zero,
+            D3D11_CREATE_DEVICE_FLAG.D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+            null,
+            0,
+            D3D11_SDK_VERSION,
+            out var d3dDevice,
+            out _,
+            out _);
+        Marshal.ThrowExceptionForHR(hr);
+        return d3dDevice;
+    }
+
     private const uint D3D11_SDK_VERSION = 7;
 
     [Flags]
@@ -49,7 +77,8 @@ public static class Direct3DDeviceHelper
 
     private enum D3D_DRIVER_TYPE
     {
-        D3D_DRIVER_TYPE_HARDWARE = 1
+        D3D_DRIVER_TYPE_HARDWARE = 1,
+        D3D_DRIVER_TYPE_WARP = 5
     }
 
     [DllImport("d3d11.dll", EntryPoint = "D3D11CreateDevice", SetLastError = true)]

--- a/src/Musio.Core/Capture/MouseHookRecorder.cs
+++ b/src/Musio.Core/Capture/MouseHookRecorder.cs
@@ -92,6 +92,7 @@ public sealed class MouseHookRecorder : IDisposable
 
     private const int DefaultSampleCapacity = 100_000;
     private const int DefaultClickCapacity  = 1_000;
+    private const double MinMoveIntervalMs = 4.0; // 250Hz cap
 
     // Binary file format constants
     private static readonly byte[] MagicBytes = "MCUR"u8.ToArray();
@@ -107,6 +108,7 @@ public sealed class MouseHookRecorder : IDisposable
     private long _startTicks;
     private long _endTicks;
     private long _stopRequestedTicks;
+    private long _lastMoveTicks;
     private bool _paused;
     private bool _disposed;
 
@@ -134,6 +136,7 @@ public sealed class MouseHookRecorder : IDisposable
             _clicks.Clear();
         }
 
+        _lastMoveTicks = 0;
         _paused = false;
         _hookReady.Reset();
         _startTicks = Stopwatch.GetTimestamp();
@@ -273,7 +276,18 @@ public sealed class MouseHookRecorder : IDisposable
 
                 lock (_lock)
                 {
-                    _samples.Add(sample);
+                    bool isPureMove = msg == WM_MOUSEMOVE;
+                    bool shouldRecordSample = !isPureMove ||
+                        _lastMoveTicks == 0 ||
+                        (ticks - _lastMoveTicks) * 1000.0 / Stopwatch.Frequency >= MinMoveIntervalMs;
+
+                    if (shouldRecordSample)
+                    {
+                        _samples.Add(sample);
+
+                        if (isPureMove)
+                            _lastMoveTicks = ticks;
+                    }
 
                     if (isClick)
                     {

--- a/src/Musio.Core/Capture/RecordingSession.cs
+++ b/src/Musio.Core/Capture/RecordingSession.cs
@@ -45,8 +45,11 @@ public class RecordingStatsEventArgs : EventArgs
 /// Master orchestrator that coordinates all capture engines
 /// (screen, mouse, audio) for a single recording session.
 /// </summary>
-public class RecordingSession : IDisposable
+public class RecordingSession : IDisposable, IAsyncDisposable
 {
+    private static readonly TimeSpan StopFinalizeTimeout = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan DisposeStopTimeout = TimeSpan.FromSeconds(30);
+
     private readonly RecordingSessionConfig _config;
     private readonly object _lock = new();
 
@@ -291,7 +294,7 @@ public class RecordingSession : IDisposable
         await Task.CompletedTask;
     }
 
-    public async Task StopAsync()
+    public async Task StopAsync(CancellationToken ct = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
@@ -309,10 +312,11 @@ public class RecordingSession : IDisposable
             // Stop elapsed timer
             _elapsedWatch.Stop();
 
-            // Stop screen capture first, then wait briefly for in-flight
-            // frame writes to complete before finalizing
+            // Stop screen capture first, then drain in-flight frame writes before finalizing.
             _screenEngine?.StopCapture();
-            await Task.Delay(500); // let queued frame writes finish
+            _videoWriter?.StopAcceptingFrames();
+            if (_videoWriter is not null)
+                await _videoWriter.WaitForQuiescenceAsync(TimeSpan.FromSeconds(10), ct).ConfigureAwait(false);
 
             _mouseRecorder?.StopRecording();
             _keyboardRecorder?.StopRecording();
@@ -336,7 +340,9 @@ public class RecordingSession : IDisposable
             {
                 try
                 {
-                    await _videoWriter.FinalizeAsync();
+                    using var finalizationCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    finalizationCts.CancelAfter(StopFinalizeTimeout);
+                    await _videoWriter.FinalizeAsync(finalizationCts.Token).ConfigureAwait(false);
                 }
                 catch (Exception finEx)
                 {
@@ -817,6 +823,41 @@ public class RecordingSession : IDisposable
 
     // ── IDisposable ─────────────────────────────────────────────────
 
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        try
+        {
+            _statsTimer?.Dispose();
+            _statsTimer = null;
+
+            if (State is RecordingState.Recording or RecordingState.Paused)
+            {
+                try
+                {
+                    using var stopCts = new CancellationTokenSource(DisposeStopTimeout);
+                    await StopAsync(stopCts.Token).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[RecordingSession] Async dispose stop failed: {ex.Message}");
+                    CleanupEngines();
+                }
+            }
+            else
+            {
+                CleanupEngines();
+            }
+        }
+        finally
+        {
+            _disposed = true;
+            GC.SuppressFinalize(this);
+        }
+    }
+
     public void Dispose()
     {
         if (_disposed)
@@ -829,8 +870,12 @@ public class RecordingSession : IDisposable
 
         if (State is RecordingState.Recording or RecordingState.Paused)
         {
-            try { StopAsync().GetAwaiter().GetResult(); }
-            catch { /* best-effort stop */ }
+            Debug.WriteLine("[RecordingSession] Dispose called while recording; stopping capture without MP4 finalization.");
+            try { _videoWriter?.StopAcceptingFrames(); } catch { }
+            try { _screenEngine?.StopCapture(); } catch { }
+            try { _mouseRecorder?.StopRecording(); } catch { }
+            try { _keyboardRecorder?.StopRecording(); } catch { }
+            try { _audioEngine?.StopRecording(); } catch { }
         }
 
         CleanupEngines();

--- a/src/Musio.Core/Capture/ScreenCaptureEngine.cs
+++ b/src/Musio.Core/Capture/ScreenCaptureEngine.cs
@@ -27,7 +27,12 @@ public sealed class ScreenCaptureEngine : IDisposable
     private long _droppedFrames;
     private long _throttledFrames;
     private volatile bool _isPaused;
-    private bool _disposed;
+    private volatile bool _itemClosed;
+    private volatile bool _disposed;
+    private readonly Windows.Foundation.TypedEventHandler<GraphicsCaptureItem, object> _captureItemClosedHandler;
+    private int _itemClosedHandled;
+    private int _captureItemClosedUnsubscribed;
+    private int _disposeStarted;
 
     // Frame-slot gating: accept at most one frame per time slot to enforce CFR pacing
     private long _lastEmittedSlot = -1;
@@ -50,6 +55,8 @@ public sealed class ScreenCaptureEngine : IDisposable
         _captureItem = item;
         _fps = fps;
         _frameInterval = TimeSpan.FromSeconds(1.0 / fps);
+        _captureItemClosedHandler = OnCaptureItemClosed;
+        _captureItem.Closed += _captureItemClosedHandler;
     }
 
     /// <summary>
@@ -156,18 +163,21 @@ public sealed class ScreenCaptureEngine : IDisposable
 
     private void OnFrameArrived(Direct3D11CaptureFramePool sender, object args)
     {
-        using var frame = sender.TryGetNextFrame();
-        if (frame is null)
-        {
-            Interlocked.Increment(ref _droppedFrames);
-            return;
-        }
-
-        if (_isPaused)
-            return;
-
         try
         {
+            if (_itemClosed)
+                return;
+
+            using var frame = sender.TryGetNextFrame();
+            if (frame is null)
+            {
+                Interlocked.Increment(ref _droppedFrames);
+                return;
+            }
+
+            if (_isPaused)
+                return;
+
             var size = frame.ContentSize;
 
             // Recreate frame pool if capture size changed
@@ -211,9 +221,68 @@ public sealed class ScreenCaptureEngine : IDisposable
                 size.Height,
                 skippedSlots));
         }
+        catch (ObjectDisposedException ex)
+        {
+            HandleFrameArrivedException(ex);
+        }
+        catch (COMException ex)
+        {
+            HandleFrameArrivedException(ex);
+        }
         catch (Exception ex)
         {
-            Error?.Invoke(this, ex.Message);
+            HandleFrameArrivedException(ex);
+        }
+    }
+
+    private void OnCaptureItemClosed(GraphicsCaptureItem sender, object args)
+    {
+        _itemClosed = true;
+
+        if (Interlocked.Exchange(ref _itemClosedHandled, 1) != 0)
+            return;
+
+        try
+        {
+            StopCapture();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (COMException ex)
+        {
+            if (!_disposed)
+                Error?.Invoke(this, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            if (!_disposed)
+                Error?.Invoke(this, ex.Message);
+        }
+    }
+
+    private void HandleFrameArrivedException(Exception ex)
+    {
+        if (_disposed || _itemClosed || !IsRecording)
+            return;
+
+        Error?.Invoke(this, ex.Message);
+    }
+
+    private void UnsubscribeCaptureItemClosed()
+    {
+        if (Interlocked.Exchange(ref _captureItemClosedUnsubscribed, 1) != 0)
+            return;
+
+        try
+        {
+            _captureItem.Closed -= _captureItemClosedHandler;
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (COMException)
+        {
         }
     }
 
@@ -286,11 +355,12 @@ public sealed class ScreenCaptureEngine : IDisposable
 
     public void Dispose()
     {
-        if (_disposed)
+        if (Interlocked.Exchange(ref _disposeStarted, 1) != 0)
             return;
 
         _disposed = true;
 
+        UnsubscribeCaptureItemClosed();
         StopCapture();
         _device.Dispose();
     }

--- a/src/Musio.Core/Capture/VideoWriter.cs
+++ b/src/Musio.Core/Capture/VideoWriter.cs
@@ -1,9 +1,13 @@
+using System.Diagnostics;
 using Microsoft.Graphics.Canvas;
 using Windows.Foundation;
 using Windows.Graphics.DirectX.Direct3D11;
-using Windows.Media.Editing;
+using Windows.Graphics.Imaging;
+using Windows.Media.Core;
 using Windows.Media.MediaProperties;
+using Windows.Media.Transcoding;
 using Windows.Storage;
+using Windows.Storage.Streams;
 
 namespace Musio.Core.Capture;
 
@@ -13,6 +17,8 @@ namespace Musio.Core.Capture;
 /// </summary>
 public sealed class VideoWriter : IDisposable
 {
+    private static readonly TimeSpan FinalizeTimeout = TimeSpan.FromMinutes(30);
+
     private readonly string _outputPath;
     private readonly string _framesDir;
     private readonly int _width;
@@ -24,6 +30,8 @@ public sealed class VideoWriter : IDisposable
     private CanvasRenderTarget? _cropTarget;
 
     private long _frameCount;
+    private int _writesInFlight;
+    private volatile bool _stopAccepting;
     private bool _finalized;
     private bool _disposed;
 
@@ -111,31 +119,38 @@ public sealed class VideoWriter : IDisposable
         if (_finalized)
             throw new InvalidOperationException("Writer has been finalized.");
 
+        if (_stopAccepting)
+            return;
+
+        Interlocked.Increment(ref _writesInFlight);
         try
         {
-            using var bitmap = CanvasBitmap.CreateFromDirect3D11Surface(_device, surface);
-
-            // Determine the image to save: cropped or full frame
-            CanvasBitmap imageToSave;
-            if (_cropRect is Rect crop)
-            {
-                _cropTarget ??= new CanvasRenderTarget(_device, _width, _height, 96);
-                using (var ds = _cropTarget.CreateDrawingSession())
-                {
-                    ds.Clear(Windows.UI.Color.FromArgb(255, 0, 0, 0));
-                    ds.DrawImage(bitmap,
-                        new Rect(0, 0, _width, _height),
-                        crop);
-                }
-                imageToSave = _cropTarget;
-            }
-            else
-            {
-                imageToSave = bitmap;
-            }
+            if (_stopAccepting)
+                return;
 
             lock (_writeLock)
             {
+                using var bitmap = CanvasBitmap.CreateFromDirect3D11Surface(_device, surface);
+
+                // Determine the image to save: cropped or full frame
+                CanvasBitmap imageToSave;
+                if (_cropRect is Rect crop)
+                {
+                    _cropTarget ??= new CanvasRenderTarget(_device, _width, _height, 96);
+                    using (var ds = _cropTarget.CreateDrawingSession())
+                    {
+                        ds.Clear(Windows.UI.Color.FromArgb(255, 0, 0, 0));
+                        ds.DrawImage(bitmap,
+                            new Rect(0, 0, _width, _height),
+                            crop);
+                    }
+                    imageToSave = _cropTarget;
+                }
+                else
+                {
+                    imageToSave = bitmap;
+                }
+
                 long index = Interlocked.Increment(ref _frameCount) - 1;
 
                 lock (_tsLock)
@@ -153,7 +168,34 @@ public sealed class VideoWriter : IDisposable
         catch (Exception ex) when (ex is not ObjectDisposedException)
         {
             // Log frame write failures prominently for debugging
-            System.Diagnostics.Debug.WriteLine($"[VideoWriter] ERROR frame {Interlocked.Read(ref _frameCount)}: {ex.GetType().Name}: {ex.Message}");
+            Debug.WriteLine($"[VideoWriter] ERROR frame {Interlocked.Read(ref _frameCount)}: {ex.GetType().Name}: {ex.Message}");
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _writesInFlight);
+        }
+    }
+
+    public void StopAcceptingFrames()
+    {
+        _stopAccepting = true;
+    }
+
+    public async Task WaitForQuiescenceAsync(TimeSpan timeout, CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+        while (Volatile.Read(ref _writesInFlight) != 0)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (sw.Elapsed >= timeout)
+                throw new TimeoutException($"Timed out waiting {timeout} for frame writes to finish.");
+
+            await Task.Delay(10, ct).ConfigureAwait(false);
+        }
+
+        lock (_writeLock)
+        {
+            // Drain any queued FillGapFrames call, which also uses this lock.
         }
     }
 
@@ -196,7 +238,7 @@ public sealed class VideoWriter : IDisposable
                 }
                 catch (Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine(
+                    Debug.WriteLine(
                         $"[VideoWriter] Gap fill failed at index {gapIndex}: {ex.Message}");
                 }
             }
@@ -204,9 +246,9 @@ public sealed class VideoWriter : IDisposable
     }
 
     /// <summary>
-    /// Assembles all captured JPEG frames into an MP4 file using <see cref="MediaComposition"/>.
+    /// Assembles all captured JPEG frames into an MP4 file by streaming BGRA8 samples to H.264.
     /// </summary>
-    public async Task FinalizeAsync()
+    public async Task FinalizeAsync(CancellationToken ct = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
@@ -230,7 +272,11 @@ public sealed class VideoWriter : IDisposable
         }
         catch { /* best effort */ }
 
-        var composition = new MediaComposition();
+        // H.264 requires even dimensions
+        uint profileWidth = (uint)(_width & ~1);
+        uint profileHeight = (uint)(_height & ~1);
+        if (profileWidth < 2) profileWidth = 2;
+        if (profileHeight < 2) profileHeight = 2;
 
         // Use constant frame duration for true CFR output.
         // The slot-based capture throttling ensures frames arrive at ~1/fps intervals,
@@ -239,84 +285,191 @@ public sealed class VideoWriter : IDisposable
 
         try
         {
-            for (long i = 0; i < totalFrames; i++)
+            File.AppendAllText(logPath,
+                $"Profile: {profileWidth}x{profileHeight}, Frames={totalFrames}\n");
+        }
+        catch { }
+
+        var videoProps = VideoEncodingProperties.CreateUncompressed(
+            MediaEncodingSubtypes.Bgra8, profileWidth, profileHeight);
+        videoProps.FrameRate.Numerator = (uint)_fps;
+        videoProps.FrameRate.Denominator = 1;
+
+        var videoDesc = new VideoStreamDescriptor(videoProps);
+        var streamSource = new MediaStreamSource(videoDesc)
+        {
+            Duration = TimeSpan.FromSeconds((double)totalFrames / _fps),
+            BufferTime = TimeSpan.Zero,
+        };
+
+        streamSource.Starting += (MediaStreamSource sender, MediaStreamSourceStartingEventArgs args) =>
+        {
+            args.Request.SetActualStartPosition(TimeSpan.Zero);
+        };
+
+        long currentFrame = -1;
+        var pendingSamples = new List<Task>();
+        var pendingSamplesLock = new object();
+        Exception? firstFrameError = null;
+        long firstFrameErrorIndex = -1;
+        var frameErrorLock = new object();
+
+        using var finalizeCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        streamSource.SampleRequested += (MediaStreamSource sender, MediaStreamSourceSampleRequestedEventArgs args) =>
+        {
+            long frame = Interlocked.Increment(ref currentFrame);
+            if (frame >= totalFrames)
             {
-                string framePath = Path.Combine(_framesDir, $"frame_{i:D8}.jpg");
-                if (!File.Exists(framePath))
-                    continue;
-
-                var file = await StorageFile.GetFileFromPathAsync(Path.GetFullPath(framePath));
-                var clip = await MediaClip.CreateFromImageFileAsync(file, constantDuration);
-                composition.Clips.Add(clip);
-            }
-
-            if (composition.Clips.Count == 0)
+                args.Request.Sample = null;
                 return;
-
-            // H.264 requires even dimensions
-            uint profileWidth = (uint)(_width & ~1);
-            uint profileHeight = (uint)(_height & ~1);
-            if (profileWidth < 2) profileWidth = 2;
-            if (profileHeight < 2) profileHeight = 2;
-
-            // Encode to MP4 — use Auto quality so the profile dimensions aren't
-            // constrained to a preset resolution, then set them explicitly.
-            var profile = MediaEncodingProfile.CreateMp4(VideoEncodingQuality.Auto);
-            profile.Video ??= new VideoEncodingProperties();
-            profile.Video.Subtype = "H264";
-            profile.Video.Width = profileWidth;
-            profile.Video.Height = profileHeight;
-            profile.Video.FrameRate.Numerator = (uint)_fps;
-            profile.Video.FrameRate.Denominator = 1;
-            profile.Video.Bitrate = 20_000_000;
-
-            try
-            {
-                File.AppendAllText(logPath,
-                    $"Profile: {profileWidth}x{profileHeight}, Clips={composition.Clips.Count}\n");
             }
+
+            var deferral = args.Request.GetDeferral();
+            var task = ProduceFrameSampleAsync(
+                args.Request, deferral, frame, (int)profileWidth, (int)profileHeight,
+                constantDuration, finalizeCts.Token,
+                onError: (ex, frameIdx) =>
+                {
+                    lock (frameErrorLock)
+                    {
+                        if (firstFrameError is null)
+                        {
+                            firstFrameError = ex;
+                            firstFrameErrorIndex = frameIdx;
+                        }
+                    }
+                });
+
+            lock (pendingSamplesLock)
+            {
+                pendingSamples.RemoveAll(t => t.IsCompleted);
+                pendingSamples.Add(task);
+            }
+        };
+
+        var profile = MediaEncodingProfile.CreateMp4(VideoEncodingQuality.Auto);
+        profile.Video ??= new VideoEncodingProperties();
+        profile.Video.Subtype = "H264";
+        profile.Video.Width = profileWidth;
+        profile.Video.Height = profileHeight;
+        profile.Video.FrameRate.Numerator = (uint)_fps;
+        profile.Video.FrameRate.Denominator = 1;
+        profile.Video.Bitrate = 20_000_000;
+        profile.Audio = null;
+
+        string dir = Path.GetDirectoryName(_outputPath)!;
+        var folder = await StorageFolder.GetFolderFromPathAsync(Path.GetFullPath(dir));
+        var outputFile = await folder.CreateFileAsync(
+            Path.GetFileName(_outputPath), CreationCollisionOption.ReplaceExisting);
+
+        using var outputStream = await outputFile.OpenAsync(FileAccessMode.ReadWrite);
+        var transcoder = new MediaTranscoder
+        {
+            HardwareAccelerationEnabled = false,
+        };
+
+        var prepResult = await transcoder.PrepareMediaStreamSourceTranscodeAsync(
+            streamSource, outputStream, profile);
+        if (!prepResult.CanTranscode)
+            throw new InvalidOperationException($"Transcoder cannot encode: {prepResult.FailureReason}");
+
+        var transcodeOp = prepResult.TranscodeAsync();
+        using var cancelRegistration = finalizeCts.Token.Register(() => transcodeOp.Cancel());
+        var transcodeTask = transcodeOp.AsTask(finalizeCts.Token);
+        var timeoutTask = Task.Delay(FinalizeTimeout);
+
+        if (await Task.WhenAny(transcodeTask, timeoutTask).ConfigureAwait(false) != transcodeTask)
+        {
+            finalizeCts.Cancel();
+            try { await transcodeTask.ConfigureAwait(false); }
+            catch { /* timeout is reported below */ }
+            throw new TimeoutException($"MP4 finalization timed out after {FinalizeTimeout}.");
+        }
+
+        await transcodeTask.ConfigureAwait(false);
+
+        Task[] snapshot;
+        lock (pendingSamplesLock)
+        {
+            snapshot = pendingSamples.ToArray();
+        }
+        await Task.WhenAll(snapshot).ConfigureAwait(false);
+
+        Exception? capturedError;
+        long capturedIndex;
+        lock (frameErrorLock)
+        {
+            capturedError = firstFrameError;
+            capturedIndex = firstFrameErrorIndex;
+        }
+        if (capturedError is not null)
+        {
+            try { File.AppendAllText(logPath, $"Frame {capturedIndex} FAILED: {capturedError}\n"); }
             catch { }
 
-            string dir = Path.GetDirectoryName(_outputPath)!;
-            var folder = await StorageFolder.GetFolderFromPathAsync(Path.GetFullPath(dir));
-            var outputFile = await folder.CreateFileAsync(
-                Path.GetFileName(_outputPath), CreationCollisionOption.ReplaceExisting);
-
-            var renderOp = composition.RenderToFileAsync(
-                outputFile, MediaTrimmingPreference.Precise, profile);
-
-            var tcs = new TaskCompletionSource<object?>();
-            renderOp.Completed = (info, status) =>
-            {
-                if (status == Windows.Foundation.AsyncStatus.Completed)
-                {
-                    tcs.TrySetResult(null);
-                }
-                else if (status == Windows.Foundation.AsyncStatus.Canceled)
-                {
-                    tcs.TrySetCanceled();
-                }
-                else
-                {
-                    var err = info.ErrorCode;
-                    try { File.AppendAllText(logPath, $"RenderToFile FAILED: {err}\n"); }
-                    catch { }
-                    tcs.TrySetException(
-                        err ?? new InvalidOperationException("MP4 render failed."));
-                }
-            };
-
-            await tcs.Task;
-        }
-        finally
-        {
-            // Release all MediaClip COM objects to avoid linear memory/handle
-            // growth proportional to frame count.
-            composition.Clips.Clear();
+            throw new InvalidOperationException(
+                $"MP4 finalization failed while decoding frame {capturedIndex}: {capturedError.Message}",
+                capturedError);
         }
 
         // Keep frame images for editor preview — they'll be cleaned up
         // when the project is explicitly deleted or on next recording.
+    }
+
+    private async Task ProduceFrameSampleAsync(
+        MediaStreamSourceSampleRequest request,
+        MediaStreamSourceSampleRequestDeferral deferral,
+        long frameIndex,
+        int width,
+        int height,
+        TimeSpan frameDuration,
+        CancellationToken ct,
+        Action<Exception, long>? onError)
+    {
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+
+            string framePath = Path.Combine(_framesDir, $"frame_{frameIndex:D8}.jpg");
+            if (!File.Exists(framePath))
+                throw new FileNotFoundException("Frame JPEG not found.", framePath);
+
+            var file = await StorageFile.GetFileFromPathAsync(Path.GetFullPath(framePath));
+            using var stream = await file.OpenAsync(FileAccessMode.Read);
+            var decoder = await BitmapDecoder.CreateAsync(stream);
+            var transform = new BitmapTransform
+            {
+                ScaledWidth = (uint)width,
+                ScaledHeight = (uint)height,
+                InterpolationMode = BitmapInterpolationMode.Fant,
+            };
+
+            using var bitmap = await decoder.GetSoftwareBitmapAsync(
+                BitmapPixelFormat.Bgra8,
+                BitmapAlphaMode.Premultiplied,
+                transform,
+                ExifOrientationMode.IgnoreExifOrientation,
+                ColorManagementMode.DoNotColorManage);
+
+            var buffer = new Windows.Storage.Streams.Buffer((uint)((long)width * height * 4));
+            bitmap.CopyToBuffer(buffer);
+
+            var timestamp = TimeSpan.FromSeconds((double)frameIndex / _fps);
+            var sample = MediaStreamSample.CreateFromBuffer(buffer, timestamp);
+            sample.Duration = frameDuration;
+            request.Sample = sample;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[VideoWriter] Finalize frame {frameIndex} error: {ex}");
+            onError?.Invoke(ex, frameIndex);
+            request.Sample = null;
+        }
+        finally
+        {
+            deferral.Complete();
+        }
     }
 
     public void Dispose()

--- a/src/Musio.Core/Export/VideoEncoder.cs
+++ b/src/Musio.Core/Export/VideoEncoder.cs
@@ -631,8 +631,7 @@ public class VideoEncoder : IDisposable
     {
         var transcodeOp = prepResult.TranscodeAsync();
         var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        using var reg = linkedCts.Token.Register(() => transcodeOp.Cancel());
+        using var reg = ct.Register(() => transcodeOp.Cancel());
         transcodeOp.Completed = (info, status) =>
         {
             if (status == Windows.Foundation.AsyncStatus.Completed)

--- a/src/Musio.Core/Export/VideoEncoder.cs
+++ b/src/Musio.Core/Export/VideoEncoder.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Microsoft.Graphics.Canvas;
 using Musio.Core.Models;
 using Musio.Core.Processing;
@@ -44,6 +45,11 @@ public class VideoEncoder : IDisposable
 {
     private readonly ExportSettings _settings;
     private bool _disposed;
+    private volatile bool _deviceLost;
+    private CanvasDevice? _deviceWithDeviceLostHandler;
+
+    private const long MaxEstimatedRenderTargetBytes = 1_610_612_736L;
+    private static readonly TimeSpan MainTranscodeTimeout = TimeSpan.FromHours(2);
 
     // Serializes frame compositing so shared state (compositor, frameReader)
     // is never accessed concurrently by overlapping SampleRequested callbacks
@@ -84,6 +90,13 @@ public class VideoEncoder : IDisposable
 
         var stopwatch = Stopwatch.StartNew();
         var device = CanvasDevice.GetSharedDevice();
+        _deviceLost = false;
+        device.DeviceLost += OnCanvasDeviceLost;
+        _deviceWithDeviceLostHandler = device;
+
+        try
+        {
+        ThrowIfDeviceLost();
 
         // Open source video for dimensions and audio tracks.
         // If the MP4 is missing or corrupt (FinalizeAsync failure during recording),
@@ -139,6 +152,7 @@ public class VideoEncoder : IDisposable
         targetWidth = encW;
         targetHeight = encH;
         bool needsScaling = targetWidth != compositorWidth || targetHeight != compositorHeight;
+        PreflightRenderTargetMemory(targetWidth, targetHeight, needsScaling);
 
         // Load source frames from .frames/ JPEGs using the RECORDING FPS so
         // frame indices map correctly to the on-disk frame numbering.
@@ -304,7 +318,7 @@ public class VideoEncoder : IDisposable
                 throw new InvalidOperationException(
                     $"Transcoder cannot encode: {prepResult.FailureReason}");
 
-            await prepResult.TranscodeAsync().AsTask(ct);
+            await TranscodeWithTimeoutAsync(prepResult, ct);
 
             // Drain any still-running sample tasks before disposing shared state
             Task[] snapshot;
@@ -360,6 +374,13 @@ public class VideoEncoder : IDisposable
                 catch { /* best-effort */ }
             }
         }
+        }
+        finally
+        {
+            device.DeviceLost -= OnCanvasDeviceLost;
+            if (ReferenceEquals(_deviceWithDeviceLostHandler, device))
+                _deviceWithDeviceLostHandler = null;
+        }
     }
 
     /// <summary>
@@ -391,6 +412,7 @@ public class VideoEncoder : IDisposable
         try
         {
             ct.ThrowIfCancellationRequested();
+            ThrowIfDeviceLost();
 
             // Serialize frame production: shared compositor/frame-reader/webcam
             // composition state is not thread-safe and can corrupt frames if
@@ -450,7 +472,7 @@ public class VideoEncoder : IDisposable
             // after we release the semaphore.
             if (needsScaling)
             {
-                outputSurface = new CanvasRenderTarget(device, targetWidth, targetHeight, 96);
+                outputSurface = CreateRenderTarget(device, targetWidth, targetHeight, "scaled encoder output");
                 using (var ds = outputSurface.CreateDrawingSession())
                 {
                     ds.DrawImage(composedFrame,
@@ -605,6 +627,81 @@ public class VideoEncoder : IDisposable
         muxComp.BackgroundAudioTracks.Clear();
     }
 
+    private async Task TranscodeWithTimeoutAsync(PrepareTranscodeResult prepResult, CancellationToken ct)
+    {
+        var transcodeOp = prepResult.TranscodeAsync();
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        using var reg = linkedCts.Token.Register(() => transcodeOp.Cancel());
+        transcodeOp.Completed = (info, status) =>
+        {
+            if (status == Windows.Foundation.AsyncStatus.Completed)
+                tcs.TrySetResult(null);
+            else if (status == Windows.Foundation.AsyncStatus.Canceled)
+                tcs.TrySetCanceled(ct);
+            else
+                tcs.TrySetException(info.ErrorCode ?? new InvalidOperationException("Video transcode failed."));
+        };
+
+        var timeoutTask = Task.Delay(MainTranscodeTimeout);
+        if (await Task.WhenAny(tcs.Task, timeoutTask) != tcs.Task)
+        {
+            ct.ThrowIfCancellationRequested();
+            transcodeOp.Cancel();
+            throw new TimeoutException(
+                $"Video transcode operation timed out after {MainTranscodeTimeout.TotalHours:0.#} hours.");
+        }
+
+        await tcs.Task;
+        ThrowIfDeviceLost();
+    }
+
+    private void PreflightRenderTargetMemory(int targetWidth, int targetHeight, bool needsScaling)
+    {
+        long estimatedBytes = needsScaling ? EstimateBgraBytes(targetWidth, targetHeight, 1) : 0;
+        if (estimatedBytes > MaxEstimatedRenderTargetBytes)
+            throw new InvalidOperationException(FormatRenderTargetMemoryLimitMessage(estimatedBytes));
+    }
+
+    private CanvasRenderTarget CreateRenderTarget(CanvasDevice device, int width, int height, string purpose)
+    {
+        ThrowIfDeviceLost();
+        try
+        {
+            return new CanvasRenderTarget(device, width, height, 96);
+        }
+        catch (Exception ex) when (ex is OutOfMemoryException or COMException)
+        {
+            throw new InvalidOperationException(
+                $"Failed to allocate {purpose} render target ({width}x{height}). " +
+                "Reduce export resolution or close other GPU-heavy applications.", ex);
+        }
+    }
+
+    private void OnCanvasDeviceLost(CanvasDevice sender, object args)
+    {
+        _deviceLost = true;
+    }
+
+    private void ThrowIfDeviceLost()
+    {
+        if (_deviceLost)
+            throw new RecoverableDeviceLostException(
+                "The graphics device was lost while exporting video. Retry the export after closing other GPU-heavy applications.");
+    }
+
+    private static long EstimateBgraBytes(int width, int height, int surfaceCount)
+    {
+        return (long)width * height * 4 * surfaceCount;
+    }
+
+    private static string FormatRenderTargetMemoryLimitMessage(long estimatedBytes)
+    {
+        long mb = estimatedBytes / (1024 * 1024);
+        long maxMb = MaxEstimatedRenderTargetBytes / (1024 * 1024);
+        return $"Estimated render target memory ({mb} MB) exceeds safe limit ({maxMb} MB). Reduce export resolution or close other GPU-heavy applications.";
+    }
+
     private MediaEncodingProfile CreateEncodingProfile(int width, int height)
     {
         // Use HD1080p as a well-formed template with valid Video + Audio
@@ -692,9 +789,23 @@ public class VideoEncoder : IDisposable
     {
         if (!_disposed)
         {
+            if (_deviceWithDeviceLostHandler is not null)
+            {
+                _deviceWithDeviceLostHandler.DeviceLost -= OnCanvasDeviceLost;
+                _deviceWithDeviceLostHandler = null;
+            }
+
             _frameSemaphore.Dispose();
             _disposed = true;
             GC.SuppressFinalize(this);
         }
+    }
+}
+
+internal sealed class RecoverableDeviceLostException : Exception
+{
+    public RecoverableDeviceLostException(string message)
+        : base(message)
+    {
     }
 }

--- a/src/Musio.Core/Processing/FrameCompositor.cs
+++ b/src/Musio.Core/Processing/FrameCompositor.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Microsoft.Graphics.Canvas;
 using Musio.Core.AI;
 using Musio.Core.Capture;
@@ -41,6 +42,9 @@ public class FrameCompositor : IDisposable
     private readonly AutoZoomEngine _zoomEngine;
     private readonly CursorSmoother _smoother;
     private readonly CompositionConfig _config;
+    private volatile bool _deviceLost;
+
+    private const long MaxEstimatedRenderTargetBytes = 1_610_612_736L;
 
     // Optional overlay renderers
     private WebcamCompositor? _webcamCompositor;
@@ -96,6 +100,7 @@ public class FrameCompositor : IDisposable
     {
         _config = config ?? throw new ArgumentNullException(nameof(config));
         _device = CanvasDevice.GetSharedDevice();
+        _device.DeviceLost += OnCanvasDeviceLost;
         _bgCompositor = new BackgroundCompositor();
         _cursorRenderer = new CursorRenderer(config.Cursor);
         _zoomEngine = new AutoZoomEngine(config.Zoom);
@@ -137,6 +142,7 @@ public class FrameCompositor : IDisposable
         float dpiScale = 0)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+        ThrowIfDeviceLost();
         ArgumentNullException.ThrowIfNull(mouseData);
         if (sourceWidth <= 0) throw new ArgumentOutOfRangeException(nameof(sourceWidth));
         if (sourceHeight <= 0) throw new ArgumentOutOfRangeException(nameof(sourceHeight));
@@ -168,6 +174,7 @@ public class FrameCompositor : IDisposable
             _contentWidth, _contentHeight, _config.Background);
         OutputWidth = outW;
         OutputHeight = outH;
+        PreflightRenderTargetMemory();
 
         // Smooth cursor path at the target FPS, subtract crop offset for
         // region recordings, and apply time offset. Mouse hook coordinates
@@ -368,6 +375,7 @@ public class FrameCompositor : IDisposable
     public CanvasRenderTarget ComposeFrame(CanvasBitmap sourceFrame, double sourceTimeSeconds)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+        ThrowIfDeviceLost();
         if (!_initialized)
             throw new InvalidOperationException("Call InitializeAsync before compositing frames.");
         ArgumentNullException.ThrowIfNull(sourceFrame);
@@ -425,7 +433,7 @@ public class FrameCompositor : IDisposable
         var croppedFrame = CropSourceFrame(sourceFrame, viewport);
 
         // Create output render target
-        var output = new CanvasRenderTarget(_device, OutputWidth, OutputHeight, 96);
+        var output = CreateRenderTarget(OutputWidth, OutputHeight, "direct composition output");
         using (var ds = output.CreateDrawingSession())
         {
             // Background + shadow + content + border
@@ -507,7 +515,7 @@ public class FrameCompositor : IDisposable
             cy_comp - cropH / 2f, 0f, Math.Max(0f, OutputHeight - cropH));
 
         // 5. Draw zoomed composite + fixed overlays
-        var output = new CanvasRenderTarget(_device, OutputWidth, OutputHeight, 96);
+        var output = CreateRenderTarget(OutputWidth, OutputHeight, "post-composite zoom output");
         using (var ds = output.CreateDrawingSession())
         {
             // Use high-quality interpolation only when zoomed; linear is cheaper at 1:1
@@ -551,8 +559,65 @@ public class FrameCompositor : IDisposable
             || _compositeBuffer.SizeInPixels.Height != (uint)OutputHeight)
         {
             _compositeBuffer?.Dispose();
-            _compositeBuffer = new CanvasRenderTarget(_device, OutputWidth, OutputHeight, 96);
+            _compositeBuffer = null;
+            _compositeBuffer = CreateRenderTarget(OutputWidth, OutputHeight, "post-composite zoom buffer");
         }
+    }
+
+    private void PreflightRenderTargetMemory()
+    {
+        long estimatedBytes = EstimateBgraBytes(OutputWidth, OutputHeight, 2)
+            + EstimateBgraBytes(_sourceAreaWidth, _sourceAreaHeight, 1);
+        if (estimatedBytes > MaxEstimatedRenderTargetBytes)
+            throw new InvalidOperationException(FormatRenderTargetMemoryLimitMessage(estimatedBytes));
+    }
+
+    private CanvasRenderTarget CreateRenderTarget(int width, int height, string purpose)
+    {
+        ThrowIfDeviceLost();
+        try
+        {
+            return new CanvasRenderTarget(_device, width, height, 96);
+        }
+        catch (Exception ex) when (ex is OutOfMemoryException or COMException)
+        {
+            ReleaseCachedRenderTargets();
+            throw new InvalidOperationException(
+                $"Failed to allocate {purpose} render target ({width}x{height}). " +
+                "Reduce export resolution or close other GPU-heavy applications.", ex);
+        }
+    }
+
+    private void ReleaseCachedRenderTargets()
+    {
+        _croppedBuffer?.Dispose();
+        _croppedBuffer = null;
+        _compositeBuffer?.Dispose();
+        _compositeBuffer = null;
+    }
+
+    private void OnCanvasDeviceLost(CanvasDevice sender, object args)
+    {
+        _deviceLost = true;
+    }
+
+    private void ThrowIfDeviceLost()
+    {
+        if (_deviceLost)
+            throw new RecoverableDeviceLostException(
+                "The graphics device was lost while compositing frames. Retry the export after closing other GPU-heavy applications.");
+    }
+
+    private static long EstimateBgraBytes(int width, int height, int surfaceCount)
+    {
+        return (long)width * height * 4 * surfaceCount;
+    }
+
+    private static string FormatRenderTargetMemoryLimitMessage(long estimatedBytes)
+    {
+        long mb = estimatedBytes / (1024 * 1024);
+        long maxMb = MaxEstimatedRenderTargetBytes / (1024 * 1024);
+        return $"Estimated render target memory ({mb} MB) exceeds safe limit ({maxMb} MB). Reduce export resolution or close other GPU-heavy applications.";
     }
 
     #region Aspect Ratio
@@ -710,7 +775,8 @@ public class FrameCompositor : IDisposable
             || _croppedBuffer.SizeInPixels.Height != (uint)_sourceAreaHeight)
         {
             _croppedBuffer?.Dispose();
-            _croppedBuffer = new CanvasRenderTarget(_device, _sourceAreaWidth, _sourceAreaHeight, 96);
+            _croppedBuffer = null;
+            _croppedBuffer = CreateRenderTarget(_sourceAreaWidth, _sourceAreaHeight, "source crop buffer");
         }
 
         // Adaptive interpolation: HighQualityCubic is a 4-tap bicubic filter,
@@ -869,10 +935,8 @@ public class FrameCompositor : IDisposable
     {
         if (!_disposed)
         {
-            _croppedBuffer?.Dispose();
-            _croppedBuffer = null;
-            _compositeBuffer?.Dispose();
-            _compositeBuffer = null;
+            _device.DeviceLost -= OnCanvasDeviceLost;
+            ReleaseCachedRenderTargets();
             _bgCompositor.Dispose();
             _cursorRenderer.Dispose();
             _webcamCompositor?.Dispose();
@@ -882,5 +946,13 @@ public class FrameCompositor : IDisposable
             _disposed = true;
             GC.SuppressFinalize(this);
         }
+    }
+}
+
+internal sealed class RecoverableDeviceLostException : Exception
+{
+    public RecoverableDeviceLostException(string message)
+        : base(message)
+    {
     }
 }


### PR DESCRIPTION
Implements 13 hardening fixes from a rubber-duck-driven review. No functionality or export-quality change; only failure-path robustness.

Capture pipeline:
- VideoWriter.FinalizeAsync now streams BGRA8 samples via MediaStreamSource
  + MediaTranscoder instead of building one MediaClip per frame. Same H.264 / 20 Mbps / CFR output. Adds CancellationToken + 30 min watchdog.
- VideoWriter tracks in-flight writes; StopAcceptingFrames + WaitForQuiescenceAsync replace fixed 500ms drain in RecordingSession.
- WriteFrame body now serialized entirely under _writeLock so concurrent free-threaded frame-pool callbacks cannot race on shared _cropTarget.
- ScreenCaptureEngine: TryGetNextFrame moved inside try/catch; suppresses ObjectDisposedException/COMException during shutdown/device-lost.
- ScreenCaptureEngine: subscribes GraphicsCaptureItem.Closed and routes to StopCapture so monitor hot-plug / window close stops cleanly.
- RecordingSession implements IAsyncDisposable; sync Dispose() no longer blocks on StopAsync().GetAwaiter().GetResult(); FinalizeAsync timeout.
- MouseHookRecorder throttles pure WM_MOUSEMOVE samples to 250 Hz (4 ms min interval); clicks/scrolls/buttons always preserved.

GPU pipeline:
- Direct3DDeviceHelper checks D3D11CreateDevice HRESULT and falls back to D3D_DRIVER_TYPE_WARP when hardware creation fails.
- FrameCompositor and VideoEncoder subscribe CanvasDevice.DeviceLost and surface a recoverable exception instead of crashing mid-frame.
- FrameCompositor and VideoEncoder add a BGRA render-target preflight (1.5 GB threshold) and wrap CanvasRenderTarget allocations in OOM/COM try/catch with cache release + context rethrow.
- VideoEncoder main-pass TranscodeAsync now has a 2-hour watchdog matching the existing audio-mux timeout pattern.

Picker overlays:
- RegionSelectorOverlay and WindowSelectorOverlay screenshot helpers reject width*height*4 > 1 GB and dimensions > 16384 px with checked long arithmetic. Falls back to solid overlay. GDI handles validated.
- WindowSelectorOverlay replaces presenter.Maximize() with AppWindow.MoveAndResize across the virtual desktop bounds.
- RegionSelectorOverlay clamps the live drag rectangle to the monitor containing the drag origin so the visual region equals what is saved.

Validation:
- VS MSBuild x64 Debug builds Musio.Core, Musio.App, Musio.Tests clean.
- All 286 MSTest tests pass (with DOTNET_ROLL_FORWARD=Major to use the installed .NET 10 runtime).