### PR TITLE
Fix HANG_QUIESCE on OS-initiated app close

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -1784,9 +1784,9 @@ the success message. Resetting on close is cleaner and matches user intent.
 
 - **Feature/area**: App lifecycle / OS quiesce handling (`App.xaml.cs`, `MainWindow.xaml.cs`)
 - **Approaches tried**:
-  1. **Catch WM_QUERYENDSESSION and treat it as quiesce signal** � previous code only handled WM_ENDSESSION, and even that used wrong constant (`0x0026` instead of `0x0016`) so it never fired. Now WndProc returns 1 to WM_QUERYENDSESSION and routes both messages to `BeginQuiesce`. ✅
-  2. **`BeginQuiesce` with hard 1.5 s safety timer** � sets `_isExiting` + `_quiesceStarted`, disposes tray/hotkey/extended-execution, posts `Window.Close()` via dispatcher, and starts a `Threading.Timer` that calls `Environment.Exit(0)` so we never exceed the OS quiesce budget. ✅
-  3. **Guarded `OnWindowClosing`** � only cancels close when `_trayService` is actually alive AND not exiting; lets OS-initiated/Task-Manager closes proceed. ✅
-  4. **Replaced `Environment.Exit(0)` in event handlers with `Application.Exit()` + safety timer** � prevents the dispatcher from being killed mid-pump (itself a HANG_QUIESCE source) while still guaranteeing process termination. ✅
-- **What worked**: All four together. The wrong WM_ENDSESSION constant (0x0026 vs 0x0016) was the root reason the earlier fix didn't help � the handler was dead code.
+  1. **Catch WM_QUERYENDSESSION and treat it as quiesce signal** — previous code only handled WM_ENDSESSION, and even that used wrong constant (`0x0026` instead of `0x0016`) so it never fired. Now WndProc returns 1 to WM_QUERYENDSESSION and routes both messages to `BeginQuiesce`. ✅
+  2. **`BeginQuiesce` with hard 1.5 s safety timer** — sets `_isExiting`, disposes tray/hotkey/extended-execution, posts `Window.Close()` via dispatcher, and starts a `Threading.Timer` that calls `Environment.Exit(0)` so we never exceed the OS quiesce budget. ✅
+  3. **Guarded `OnWindowClosing`** — only cancels close when `_trayService` is actually alive AND not exiting; lets OS-initiated/Task-Manager closes proceed. ✅
+  4. **Replaced `Environment.Exit(0)` in event handlers with `Application.Exit()` + safety timer** — prevents the dispatcher from being killed mid-pump (itself a HANG_QUIESCE source) while still guaranteeing process termination. ✅
+- **What worked**: All four together. The wrong WM_ENDSESSION constant (0x0026 vs 0x0016) was the root reason the earlier fix didn't help — the handler was dead code.
 - **Bugs found in pre-existing code**: WM_ENDSESSION constant was 0x0026; correct value is 0x0016. Previous `HandleSystemShutdown` disposed services but never closed the window or posted WM_QUIT, so the pump kept running after WM_ENDSESSION even if it had fired.

--- a/learnings.md
+++ b/learnings.md
@@ -1777,3 +1777,16 @@ the success message. Resetting on close is cleaner and matches user intent.
 **What worked:**
 - Cleaning bin/obj before each platform build avoids stale artifacts.
 - Building x64 and ARM64 separately (Platform=x64 then Platform=ARM64) produces per-arch .msix in bin\{Platform}\Release\net9.0-windows10.0.26100.0\win-{rid}\AppPackages\.
+
+---
+
+## HANG_QUIESCE Comprehensive Fix (44% of crash bucket)
+
+- **Feature/area**: App lifecycle / OS quiesce handling (`App.xaml.cs`, `MainWindow.xaml.cs`)
+- **Approaches tried**:
+  1. **Catch WM_QUERYENDSESSION and treat it as quiesce signal** — previous code only handled WM_ENDSESSION, and even that used wrong constant (`0x0026` instead of `0x0016`) so it never fired. Now WndProc returns 1 to WM_QUERYENDSESSION and routes both messages to `BeginQuiesce`. âœ…
+  2. **`BeginQuiesce` with hard 1.5 s safety timer** — sets `_isExiting` + `_quiesceStarted`, disposes tray/hotkey/extended-execution, posts `Window.Close()` via dispatcher, and starts a `Threading.Timer` that calls `Environment.Exit(0)` so we never exceed the OS quiesce budget. âœ…
+  3. **Guarded `OnWindowClosing`** — only cancels close when `_trayService` is actually alive AND not exiting; lets OS-initiated/Task-Manager closes proceed. âœ…
+  4. **Replaced `Environment.Exit(0)` in event handlers with `Application.Exit()` + safety timer** — prevents the dispatcher from being killed mid-pump (itself a HANG_QUIESCE source) while still guaranteeing process termination. âœ…
+- **What worked**: All four together. The wrong WM_ENDSESSION constant (0x0026 vs 0x0016) was the root reason the earlier fix didn't help — the handler was dead code.
+- **Bugs found in pre-existing code**: WM_ENDSESSION constant was 0x0026; correct value is 0x0016. Previous `HandleSystemShutdown` disposed services but never closed the window or posted WM_QUIT, so the pump kept running after WM_ENDSESSION even if it had fired.

--- a/src/Musio.App/App.xaml.cs
+++ b/src/Musio.App/App.xaml.cs
@@ -22,7 +22,6 @@ public partial class App : Application
     private GlobalHotkeyService? _hotkeyService;
     private ExtendedExecutionSession? _extendedSession;
     private bool _isExiting;
-    private bool _quiesceStarted;
     private System.Threading.Timer? _quiesceTimer;
 
     /// <summary>The main application window, accessible for minimize/restore operations.</summary>
@@ -121,27 +120,28 @@ public partial class App : Application
     }
 
     /// <summary>
-    /// Called when the OS asks the app to close (logoff, shutdown, MSIX
-    /// update, Task Manager end-task). Starts a bounded shutdown so the
-    /// process always exits within the OS quiesce budget instead of
-    /// hanging in <see cref="OnWindowClosing"/> and producing HANG_QUIESCE.
-    /// Safe to call multiple times.
+    /// Begins a bounded shutdown. Used for both OS-initiated quiesce
+    /// (logoff, shutdown, MSIX update, Task Manager end-task) and the
+    /// user-initiated tray "Exit" command, so the two paths can't drift.
+    /// Idempotent. Always exits the process within the OS quiesce budget
+    /// via a hard <see cref="System.Threading.Timer"/> safety net.
     /// </summary>
-    public void BeginQuiesce()
+    /// <param name="timeoutMs">
+    /// Hard upper bound (ms) before <c>Environment.Exit</c> is forced.
+    /// Defaults to 1500 ms to stay well under the OS quiesce window
+    /// (~2 s on package update, ~5 s on shutdown).
+    /// </param>
+    public void BeginQuiesce(int timeoutMs = 1500)
     {
-        if (_quiesceStarted) return;
-        _quiesceStarted = true;
+        if (_isExiting) return;
         _isExiting = true;
 
         try { ReleaseExtendedExecution(); } catch { }
         try { _hotkeyService?.Dispose(); } catch { }
         try { _trayService?.Dispose(); } catch { }
 
-        // Hard safety net: if the dispatcher can't drain in time, force
-        // exit before the OS marks us as hung. OS quiesce budget is
-        // ~5 seconds on the shutdown path and as low as ~2 s on update.
         _quiesceTimer = new System.Threading.Timer(
-            _ => Environment.Exit(0), null, 1500, System.Threading.Timeout.Infinite);
+            _ => Environment.Exit(0), null, timeoutMs, System.Threading.Timeout.Infinite);
 
         try
         {
@@ -239,18 +239,11 @@ public partial class App : Application
 
     private void OnExitRequested(object? sender, EventArgs e)
     {
-        if (_quiesceStarted) return;
-        _quiesceStarted = true;
-        _isExiting = true;
-
-        try { _hotkeyService?.Dispose(); } catch { }
-        try { _trayService?.Dispose(); } catch { }
-
-        // Safety net so we never linger after user-initiated exit either.
-        _quiesceTimer = new System.Threading.Timer(
-            _ => Environment.Exit(0), null, 2000, System.Threading.Timeout.Infinite);
-
-        try { _window?.Close(); } catch { Environment.Exit(0); }
+        // User-initiated exit shares the same shutdown routine as OS
+        // quiesce so the two paths can't drift; a slightly longer
+        // timeout gives the dispatcher more room to drain cleanly when
+        // we're not racing the OS quiesce budget.
+        BeginQuiesce(timeoutMs: 2000);
     }
 
     private void OnWindowClosing(Microsoft.UI.Windowing.AppWindow sender, Microsoft.UI.Windowing.AppWindowClosingEventArgs args)
@@ -272,7 +265,8 @@ public partial class App : Application
     {
         // The main window has closed. Ask the framework to shut the app
         // down cleanly, with a hard timer as a safety net in case the
-        // dispatcher can't drain (e.g. during OS quiesce).
+        // dispatcher can't drain (e.g. during OS quiesce). If BeginQuiesce
+        // already armed a timer we don't need a second one.
         if (_quiesceTimer is null)
         {
             _quiesceTimer = new System.Threading.Timer(

--- a/src/Musio.App/App.xaml.cs
+++ b/src/Musio.App/App.xaml.cs
@@ -22,6 +22,8 @@ public partial class App : Application
     private GlobalHotkeyService? _hotkeyService;
     private ExtendedExecutionSession? _extendedSession;
     private bool _isExiting;
+    private bool _quiesceStarted;
+    private System.Threading.Timer? _quiesceTimer;
 
     /// <summary>The main application window, accessible for minimize/restore operations.</summary>
     public Window? MainAppWindow => _window;
@@ -119,17 +121,46 @@ public partial class App : Application
     }
 
     /// <summary>
-    /// Called by MainWindow when WM_ENDSESSION is received — allows the
-    /// app to exit cleanly during system shutdown instead of cancelling the
-    /// close and triggering a HANG_QUIESCE timeout.
+    /// Called when the OS asks the app to close (logoff, shutdown, MSIX
+    /// update, Task Manager end-task). Starts a bounded shutdown so the
+    /// process always exits within the OS quiesce budget instead of
+    /// hanging in <see cref="OnWindowClosing"/> and producing HANG_QUIESCE.
+    /// Safe to call multiple times.
     /// </summary>
-    public void HandleSystemShutdown()
+    public void BeginQuiesce()
     {
+        if (_quiesceStarted) return;
+        _quiesceStarted = true;
         _isExiting = true;
-        ReleaseExtendedExecution();
-        _hotkeyService?.Dispose();
-        _trayService?.Dispose();
+
+        try { ReleaseExtendedExecution(); } catch { }
+        try { _hotkeyService?.Dispose(); } catch { }
+        try { _trayService?.Dispose(); } catch { }
+
+        // Hard safety net: if the dispatcher can't drain in time, force
+        // exit before the OS marks us as hung. OS quiesce budget is
+        // ~5 seconds on the shutdown path and as low as ~2 s on update.
+        _quiesceTimer = new System.Threading.Timer(
+            _ => Environment.Exit(0), null, 1500, System.Threading.Timeout.Infinite);
+
+        try
+        {
+            _window?.DispatcherQueue.TryEnqueue(() =>
+            {
+                try { _window?.Close(); }
+                catch { Environment.Exit(0); }
+            });
+        }
+        catch
+        {
+            Environment.Exit(0);
+        }
     }
+
+    /// <summary>
+    /// Back-compat shim — older call sites used this name.
+    /// </summary>
+    public void HandleSystemShutdown() => BeginQuiesce();
 
     private void OnWindowVisibilityChanged(object sender, WindowVisibilityChangedEventArgs args)
     {
@@ -208,21 +239,30 @@ public partial class App : Application
 
     private void OnExitRequested(object? sender, EventArgs e)
     {
+        if (_quiesceStarted) return;
+        _quiesceStarted = true;
         _isExiting = true;
-        _hotkeyService?.Dispose();
-        _trayService?.Dispose();
-        _window?.Close();
-        // WinUI 3 may not terminate after the last window closes, and
-        // Window.Closed may not fire reliably for hidden windows.
-        // Force exit so the process never lingers in the task manager.
-        Environment.Exit(0);
+
+        try { _hotkeyService?.Dispose(); } catch { }
+        try { _trayService?.Dispose(); } catch { }
+
+        // Safety net so we never linger after user-initiated exit either.
+        _quiesceTimer = new System.Threading.Timer(
+            _ => Environment.Exit(0), null, 2000, System.Threading.Timeout.Infinite);
+
+        try { _window?.Close(); } catch { Environment.Exit(0); }
     }
 
     private void OnWindowClosing(Microsoft.UI.Windowing.AppWindow sender, Microsoft.UI.Windowing.AppWindowClosingEventArgs args)
     {
+        // Never block an OS- or user-initiated exit.
         if (_isExiting || _window is null) return;
 
-        // Minimize to tray instead of exiting
+        // If the tray isn't available we have no way to bring the app
+        // back, so let the close proceed instead of stranding the process.
+        if (_trayService is null) return;
+
+        // User clicked the window's X — minimize to tray.
         args.Cancel = true;
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(_window);
         ShowWindow(hwnd, SW_HIDE);
@@ -230,11 +270,16 @@ public partial class App : Application
 
     private void OnWindowClosed(object sender, WindowEventArgs args)
     {
-        // WinUI 3 does not terminate the process when the last window closes.
-        // Handles the non-tray exit path (no OnExitRequested).
-        // Skip service disposal here — the OS reclaims all resources on exit,
-        // and Dispose during window teardown can be unreliable.
-        Environment.Exit(0);
+        // The main window has closed. Ask the framework to shut the app
+        // down cleanly, with a hard timer as a safety net in case the
+        // dispatcher can't drain (e.g. during OS quiesce).
+        if (_quiesceTimer is null)
+        {
+            _quiesceTimer = new System.Threading.Timer(
+                _ => Environment.Exit(0), null, 1500, System.Threading.Timeout.Infinite);
+        }
+
+        try { Exit(); } catch { Environment.Exit(0); }
     }
 
     private const int SW_HIDE = 0;

--- a/src/Musio.App/MainWindow.xaml.cs
+++ b/src/Musio.App/MainWindow.xaml.cs
@@ -53,7 +53,8 @@ public sealed partial class MainWindow : Window
     private IntPtr WndProc(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam)
     {
         const uint WM_GETMINMAXINFO = 0x0024;
-        const uint WM_ENDSESSION = 0x0026;
+        const uint WM_QUERYENDSESSION = 0x0011;
+        const uint WM_ENDSESSION = 0x0016;
 
         if (msg == WM_GETMINMAXINFO)
         {
@@ -64,11 +65,20 @@ public sealed partial class MainWindow : Window
             return IntPtr.Zero;
         }
 
-        // System shutdown / logoff — let the app exit cleanly instead of
-        // hiding to tray and causing a HANG_QUIESCE timeout.
+        // Any OS-initiated session/quiesce signal: tell the OS we can close
+        // and start a bounded shutdown so we never exceed the quiesce timeout.
+        // This covers logoff, shutdown, MSIX update (ENDSESSION_CLOSEAPP), and
+        // Task Manager's "End task" path.
+        if (msg == WM_QUERYENDSESSION)
+        {
+            App.Current.BeginQuiesce();
+            return new IntPtr(1);
+        }
+
         if (msg == WM_ENDSESSION && wParam != IntPtr.Zero)
         {
-            App.Current.HandleSystemShutdown();
+            App.Current.BeginQuiesce();
+            return IntPtr.Zero;
         }
 
         return CallWindowProc(_originalWndProc, hwnd, msg, wParam, lParam);


### PR DESCRIPTION
Previously OnWindowClosing unconditionally cancelled the close to minimize to tray, which trapped the process during OS quiesce (logoff, shutdown, MSIX update, Task Manager end-task) and produced HANG_QUIESCE reports (44% of crash bucket on hosted packages).

Root cause also included a dead handler: WM_ENDSESSION was checked against 0x0026 instead of the correct 0x0016, so the earlier quiesce mitigation never fired.

Changes:
- MainWindow.WndProc: handle WM_QUERYENDSESSION (0x0011) and the real WM_ENDSESSION (0x0016); route both to App.BeginQuiesce.
- App.BeginQuiesce: idempotent shutdown that disposes tray/hotkey/extended execution, posts Window.Close via the dispatcher, and arms a 1.5s Threading.Timer safety net (Environment.Exit) so we never exceed the OS quiesce budget.
- App.OnWindowClosing: only cancels close when the tray service is alive AND not exiting; lets OS- and Task-Manager-initiated closes proceed.
- App.OnExitRequested / OnWindowClosed: stop killing the dispatcher mid-pump with Environment.Exit; use Application.Exit and keep the hard timer as the last-resort safety net.
- HandleSystemShutdown kept as a shim that delegates to BeginQuiesce.